### PR TITLE
Fix content examples for OAS2

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "yalc.watch": "nodemon --watch 'src/**/*' --exec 'yarn yalc'"
   },
   "dependencies": {
-    "@stoplight/json": "^2.3.2",
+    "@stoplight/json": "^3.0.1",
     "@stoplight/types": "^9.1.2",
     "@types/swagger-schema-official": "~2.0.18",
     "@types/urijs": "~1.19.1",
@@ -43,7 +43,7 @@
     "urijs": "~1.19.1"
   },
   "devDependencies": {
-    "@stoplight/scripts": "7.x.x",
+    "@stoplight/scripts": "7.0.3",
     "@stoplight/test-utils": "^0.0.1",
     "@types/jest": "24.x.x",
     "@types/json-schema": "7.0.x",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">=10"
   },
   "scripts": {
-    "build": "sl-scripts build",
+    "build": "tsc -p ./tsconfig.build.json -d",
     "commit": "git-cz",
     "lint": "tslint -c tslint.json 'src/**/*.ts'",
     "lint.fix": "yarn lint --fix",

--- a/src/oas2/transformers/__tests__/__snapshots__/responses.test.ts.snap
+++ b/src/oas2/transformers/__tests__/__snapshots__/responses.test.ts.snap
@@ -8,11 +8,16 @@ Array [
       Object {
         "examples": Array [
           Object {
-            "key": "e1",
+            "key": "application/json",
             "value": Object {},
           },
         ],
-        "mediaType": "*",
+        "mediaType": "application/json",
+        "schema": Object {},
+      },
+      Object {
+        "examples": Array [],
+        "mediaType": "application/xml",
         "schema": Object {},
       },
     ],
@@ -28,13 +33,18 @@ Array [
     "code": "r2",
     "contents": Array [
       Object {
+        "examples": Array [],
+        "mediaType": "application/json",
+        "schema": Object {},
+      },
+      Object {
         "examples": Array [
           Object {
-            "key": "e2",
+            "key": "application/xml",
             "value": Object {},
           },
         ],
-        "mediaType": "*",
+        "mediaType": "application/xml",
         "schema": Object {},
       },
     ],
@@ -56,7 +66,12 @@ Array [
     "contents": Array [
       Object {
         "examples": Array [],
-        "mediaType": "*",
+        "mediaType": "application/json",
+        "schema": Object {},
+      },
+      Object {
+        "examples": Array [],
+        "mediaType": "application/xml",
         "schema": Object {},
       },
     ],
@@ -77,13 +92,18 @@ Array [
     "code": "r1",
     "contents": Array [
       Object {
+        "examples": Array [],
+        "mediaType": "application/json",
+        "schema": Object {},
+      },
+      Object {
         "examples": Array [
           Object {
-            "key": "e1",
+            "key": "application/xml",
             "value": Object {},
           },
         ],
-        "mediaType": "*",
+        "mediaType": "application/xml",
         "schema": Object {},
       },
     ],

--- a/src/oas2/transformers/__tests__/responses.test.ts
+++ b/src/oas2/transformers/__tests__/responses.test.ts
@@ -7,7 +7,7 @@ jest.mock('../params');
 
 describe('responses', () => {
   const fakeHeaderParams: IHttpHeaderParam[] = [{ name: 'fake-header', style: HttpParamStyles.Simple }];
-  const produces = ['*'];
+  const produces = ['application/json', 'application/xml'];
 
   beforeEach(() => {
     (translateToHeaderParams as jest.Mock).mockReturnValue(fakeHeaderParams);
@@ -18,7 +18,7 @@ describe('responses', () => {
         r1: {
           description: 'd1',
           examples: {
-            e1: {},
+            'application/json': {},
           },
           headers: {},
           schema: {},
@@ -26,7 +26,7 @@ describe('responses', () => {
         r2: {
           description: 'd2',
           examples: {
-            e2: {},
+            'application/xml': {},
           },
           headers: {},
           schema: {},
@@ -45,7 +45,7 @@ describe('responses', () => {
           r1: {
             description: 'd1',
             examples: {
-              e1: {},
+              'application/xml': {},
             },
             schema: {},
           },

--- a/src/oas2/transformers/responses.ts
+++ b/src/oas2/transformers/responses.ts
@@ -16,7 +16,7 @@ function translateToResponse(produces: string[], response: Response, statusCode:
     contents: produces.map(mediaType => ({
       mediaType,
       schema: response.schema as JSONSchema4,
-      examples: map(response.examples, toObject),
+      examples: map(response.examples, toObject).filter(example => example.key === mediaType),
     })),
     // `links` not supported by oas2
   };

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -11,6 +11,7 @@
   ],
   "compilerOptions": {
     "outDir": "dist",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "module": "es6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -751,25 +751,20 @@
     lodash "^4.17.4"
     read-pkg-up "^6.0.0"
 
-"@stoplight/fast-safe-stringify@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@stoplight/fast-safe-stringify/-/fast-safe-stringify-2.1.2.tgz#2811eff4989c3d4c5c9a3789f057e25358db0899"
-  integrity sha512-ayw3qQ9KNn2K5q6ggrLclh+rdZsSLwYIUz3uAer1NzaCpalJLR4g32G845ylgq7Xy2AunMHnNfD3FC3s0rUcsA==
-
-"@stoplight/json@^2.3.2":
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/@stoplight/json/-/json-2.3.2.tgz#da757bdb1be7440feaa8c359c95c50ac5e7a5f4e"
-  integrity sha512-V8zdMTzLYDmWJBWe+zpF8Qm/0Mw4AMhXJcmB7U1ShXNtylcD7+TvFllg5PuhH/TSAD+yHstRMZQ5zMwPOEeI0Q==
+"@stoplight/json@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@stoplight/json/-/json-3.0.1.tgz#e81345a2874486523c215282b252d70259c9c739"
+  integrity sha512-xsqbuXcvv6tepeifrtsRXXVLXzCJurESwUiZQx0SRmRGAk3EEANRrClZMOQf0LCSp2RoJkSd8Ch66tCO+079Xw==
   dependencies:
-    "@stoplight/fast-safe-stringify" "^2.1.2"
     "@stoplight/types" "^9.1.2"
-    jsonc-parser "~2.1.0"
-    lodash "^4.10"
+    jsonc-parser "~2.1"
+    lodash "^4.17"
+    safe-stable-stringify "^1.1"
 
-"@stoplight/scripts@7.x.x":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@stoplight/scripts/-/scripts-7.0.2.tgz#7ff1a6c7a1de4961e6bba3894236c7708d73910e"
-  integrity sha512-A4QDtK9IsGAdhCnY0zgXPOCLcce0D7mgahCpBPFtP9kaSdsFLuTwd+rneexz9Lf+1yyxonzP67w6ZmNBz7FeHw==
+"@stoplight/scripts@7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@stoplight/scripts/-/scripts-7.0.3.tgz#024805f3a97c349836a50821b5ddf68d142be27d"
+  integrity sha512-7QybaFhfWTnI9O7MOFEHwWx0FfXMPgt7I16RvRv85CGFIzQxg3lBIhCsil7JuGvOVnpN19bHvjojhBbXAVrUfg==
   dependencies:
     "@commitlint/cli" "7.6.1"
     "@commitlint/config-conventional" "7.6.0"
@@ -4417,7 +4412,7 @@ json5@2.x, json5@^2.1.0:
   dependencies:
     minimist "^1.2.0"
 
-jsonc-parser@~2.1.0:
+jsonc-parser@~2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-2.1.0.tgz#eb0d0c7a3c33048524ce3574c57c7278fb2f1bf3"
   integrity sha512-n9GrT8rrr2fhvBbANa1g+xFmgGK5X91KFeDwlKQ3+SJfmH5+tKv/M/kahx/TXOMflfWHKGKqKyfHQaLKTNzJ6w==
@@ -4892,7 +4887,7 @@ lodash@4.17.11:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
-lodash@^4.10, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.2.1:
+lodash@^4.17, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.2.1:
   version "4.17.14"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
   integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
@@ -6919,6 +6914,11 @@ safe-regex@^1.1.0:
   integrity sha1-QKNmnzsHfR6UPURinhV91IAjvy4=
   dependencies:
     ret "~0.1.10"
+
+safe-stable-stringify@^1.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-1.1.0.tgz#f712b600f8f775444ccc66e8f31d250e43fdfe01"
+  integrity sha512-8h+96qSufNQrydRPzbHms38VftQQSRGbqUkaIMWUBWN4/N8sLNALIALa8KmFcQ8P/a9uzMkA+KY04Rj5WQiXPA==
 
 "safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2178,7 +2178,7 @@ debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -3451,7 +3451,7 @@ import-local@^2.0.0:
     pkg-dir "^3.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -4564,7 +4564,7 @@ libnpm@^2.0.1:
     read-package-json "^2.0.13"
     stringify-package "^1.0.0"
 
-libnpmaccess@*, libnpmaccess@^3.0.1:
+libnpmaccess@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/libnpmaccess/-/libnpmaccess-3.0.1.tgz#5b3a9de621f293d425191aa2e779102f84167fa8"
   integrity sha512-RlZ7PNarCBt+XbnP7R6PoVgOq9t+kou5rvhaInoNibhPO7eMlRfS0B8yjatgn2yaHIwWNyoJDolC/6Lc5L/IQA==
@@ -4593,7 +4593,7 @@ libnpmhook@^5.0.2:
     get-stream "^4.0.0"
     npm-registry-fetch "^3.8.0"
 
-libnpmorg@*, libnpmorg@^1.0.0:
+libnpmorg@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/libnpmorg/-/libnpmorg-1.0.0.tgz#979b868c48ba28c5820e3bb9d9e73c883c16a232"
   integrity sha512-o+4eVJBoDGMgRwh2lJY0a8pRV2c/tQM/SxlqXezjcAg26Qe9jigYVs+Xk0vvlYDWCDhP0g74J8UwWeAgsB7gGw==
@@ -4618,7 +4618,7 @@ libnpmpublish@^1.1.0:
     semver "^5.5.1"
     ssri "^6.0.1"
 
-libnpmsearch@*, libnpmsearch@^2.0.0:
+libnpmsearch@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/libnpmsearch/-/libnpmsearch-2.0.1.tgz#eccc73a8fbf267d765d18082b85daa2512501f96"
   integrity sha512-K0yXyut9MHHCAH+DOiglQCpmBKPZXSUu76+BE2maSEfQN15OwNaA/Aiioe9lRFlVFOr7WcuJCY+VSl+gLi9NTA==
@@ -4627,7 +4627,7 @@ libnpmsearch@*, libnpmsearch@^2.0.0:
     get-stream "^4.0.0"
     npm-registry-fetch "^3.8.0"
 
-libnpmteam@*, libnpmteam@^1.0.1:
+libnpmteam@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/libnpmteam/-/libnpmteam-1.0.1.tgz#ff704b1b6c06ea674b3b1101ac3e305f5114f213"
   integrity sha512-gDdrflKFCX7TNwOMX1snWojCoDE5LoRWcfOC0C/fqF7mBq8Uz9zWAX4B2RllYETNO7pBupBaSyBDkTAC15cAMg==
@@ -4779,11 +4779,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -4792,32 +4787,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -4863,11 +4836,6 @@ lodash.map@^4.5.1:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
   integrity sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -5621,7 +5589,7 @@ npm-pick-manifest@^2.2.3:
     npm-package-arg "^6.0.0"
     semver "^5.4.1"
 
-npm-profile@*, npm-profile@^4.0.1:
+npm-profile@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/npm-profile/-/npm-profile-4.0.1.tgz#d350f7a5e6b60691c7168fbb8392c3603583f5aa"
   integrity sha512-NQ1I/1Q7YRtHZXkcuU1/IyHeLy6pd+ScKg4+DQHdfsm769TGq6HPrkbuNJVJS4zwE+0mvvmeULzQdWn2L2EsVA==


### PR DESCRIPTION
In the current implementation every example gets copied in every content — but they should not. In OAS2 the *key* of the example is the *mimeType* of the example itself, and they should go in their relative content.