### PR TITLE
fix: check array includes only if style is defined

### DIFF
--- a/src/oas3/transformers/__tests__/content.test.ts
+++ b/src/oas3/transformers/__tests__/content.test.ts
@@ -114,6 +114,24 @@ describe('translateMediaTypeObject', () => {
     };
     expect(testedFunction).toThrowErrorMatchingSnapshot();
   });
+
+  test('given encoding with no style it should not throw an error', () => {
+    const testedFunction = () => {
+      translateMediaTypeObject(
+        {
+          schema: {},
+          examples: { example: { summary: 'multi example' } },
+          encoding: {
+            enc1: {
+              contentType: 'text/plain',
+            },
+          },
+        },
+        'mediaType',
+      );
+    };
+    expect(() => testedFunction()).not.toThrow();
+  });
 });
 
 describe('translateHeaderObject', () => {

--- a/src/oas3/transformers/content.ts
+++ b/src/oas3/transformers/content.ts
@@ -16,7 +16,7 @@ function translateEncodingPropertyObject(
     HttpParamStyles.DeepObject,
   ];
 
-  if (!acceptableStyles.includes(encodingPropertyObject.style)) {
+  if (encodingPropertyObject.style && !acceptableStyles.includes(encodingPropertyObject.style)) {
     throw new Error(
       `Encoding property style: '${encodingPropertyObject.style}' is incorrect, must be one of: ${acceptableStyles}`,
     );


### PR DESCRIPTION
This is required to bring https://github.com/stoplightio/prism/issues/496 over the finish line