### PR TITLE
fix(content): include whole example

### DIFF
--- a/src/oas3/transformers/__tests__/__snapshots__/content.test.ts.snap
+++ b/src/oas3/transformers/__tests__/__snapshots__/content.test.ts.snap
@@ -54,7 +54,10 @@ Object {
   "examples": Array [
     Object {
       "key": "example",
-      "value": "hey",
+      "value": Object {
+        "summary": "multi example",
+        "value": "hey",
+      },
     },
   ],
   "mediaType": "mediaType",
@@ -105,7 +108,11 @@ Object {
   "examples": Array [
     Object {
       "key": "example",
-      "value": "hey",
+      "value": Object {
+        "id": 12133433,
+        "summary": "multi example",
+        "value": "hey",
+      },
     },
   ],
   "mediaType": "mediaType",
@@ -121,7 +128,10 @@ Object {
   "examples": Array [
     Object {
       "key": "example",
-      "value": "hey",
+      "value": Object {
+        "summary": "multi example",
+        "value": "hey",
+      },
     },
   ],
   "mediaType": "mediaType",

--- a/src/oas3/transformers/__tests__/content.test.ts
+++ b/src/oas3/transformers/__tests__/content.test.ts
@@ -36,7 +36,13 @@ describe('translateMediaTypeObject', () => {
       translateMediaTypeObject(
         {
           schema: {},
-          examples: { example: { summary: 'multi example', value: 'hey' } },
+          examples: {
+            example: {
+              id: 12133433,
+              summary: 'multi example',
+              value: 'hey',
+            },
+          },
           encoding: {
             enc1: {
               contentType: 'text/plain',

--- a/src/oas3/transformers/content.ts
+++ b/src/oas3/transformers/content.ts
@@ -3,7 +3,7 @@ import { JSONSchema4 } from 'json-schema';
 import { compact, get, keys, map, omit, pickBy, union, values } from 'lodash';
 // @ts-ignore
 import * as toJsonSchema from 'openapi-schema-to-json-schema';
-import { EncodingPropertyObject, ExampleObject, HeaderObject, MediaTypeObject } from 'openapi3-ts';
+import { EncodingPropertyObject, HeaderObject, MediaTypeObject } from 'openapi3-ts';
 
 function translateEncodingPropertyObject(
   encodingPropertyObject: EncodingPropertyObject,
@@ -93,7 +93,7 @@ export function translateMediaTypeObject(
         example ? [{ key: 'default', value: example }] : undefined,
         Object.keys(examples).map<INodeExample>(exampleKey => ({
           key: exampleKey,
-          value: (examples[exampleKey] as ExampleObject).value,
+          value: examples[exampleKey],
         })),
       ),
     ),


### PR DESCRIPTION
Addresses https://github.com/stoplightio/studio/issues/80.
The question is - why did we decide to pick property `value` only? If it was intended, perhaps the issue reported in Studio is not an actual bug but a feature?