### PR TITLE
fix: revert example value change

### DIFF
--- a/src/oas3/transformers/__tests__/__snapshots__/content.test.ts.snap
+++ b/src/oas3/transformers/__tests__/__snapshots__/content.test.ts.snap
@@ -11,6 +11,7 @@ Object {
     Object {
       "description": undefined,
       "key": "a",
+      "summary": "example summary",
       "value": "hey",
     },
     Object {
@@ -39,6 +40,7 @@ Object {
             Object {
               "description": undefined,
               "key": "a",
+              "summary": "example summary",
               "value": "hey",
             },
           ],
@@ -53,11 +55,10 @@ Object {
   ],
   "examples": Array [
     Object {
+      "description": undefined,
       "key": "example",
-      "value": Object {
-        "summary": "multi example",
-        "value": "hey",
-      },
+      "summary": "multi example",
+      "value": "hey",
     },
   ],
   "mediaType": "mediaType",
@@ -107,12 +108,10 @@ Object {
   ],
   "examples": Array [
     Object {
+      "description": undefined,
       "key": "example",
-      "value": Object {
-        "id": 12133433,
-        "summary": "multi example",
-        "value": "hey",
-      },
+      "summary": "multi example",
+      "value": "hey",
     },
   ],
   "mediaType": "mediaType",
@@ -127,11 +126,10 @@ Object {
   "encodings": Array [],
   "examples": Array [
     Object {
+      "description": undefined,
       "key": "example",
-      "value": Object {
-        "summary": "multi example",
-        "value": "hey",
-      },
+      "summary": "multi example",
+      "value": "hey",
     },
   ],
   "mediaType": "mediaType",

--- a/src/oas3/transformers/content.ts
+++ b/src/oas3/transformers/content.ts
@@ -98,7 +98,9 @@ export function translateMediaTypeObject(
         example ? [{ key: 'default', value: example }] : undefined,
         Object.keys(examples).map<INodeExample>(exampleKey => ({
           key: exampleKey,
-          value: examples[exampleKey],
+          summary: get(examples, [exampleKey, 'summary']),
+          description: get(examples, [exampleKey, 'description']),
+          value: get(examples, [exampleKey, 'value']),
         })),
       ),
     ),
@@ -106,8 +108,9 @@ export function translateMediaTypeObject(
   };
 }
 
-const transformExamples = (source: MediaTypeObject | HeaderObject) => (key: string) => {
+const transformExamples = (source: MediaTypeObject | HeaderObject) => (key: string): INodeExample => {
   return {
+    summary: get(source, ['examples', key, 'summary']),
     description: get(source, ['examples', key, 'description']),
     value: get(source, ['examples', key, 'value']),
     key,


### PR DESCRIPTION
- Examples should have a key, value, summary, and description property as described in https://github.com/stoplightio/types/blob/master/src/graph.ts#L27
- Related to https://github.com/stoplightio/studio-internal/pull/706
- OAS3 examples have a value property: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#example-object
- https://swagger.io/docs/specification/adding-examples/