### PR TITLE
Do not create default produces

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,14 +45,14 @@
     "@types/json-schema": "7.0.x",
     "@types/lodash": "4.14.138",
     "jest": "24.9.0",
-    "nodemon": "1.x.x",
+    "nodemon": "1.19.2",
     "prettier": "1.x.x",
-    "ts-jest": "24.x.x",
-    "tslint": "5.19.0",
+    "ts-jest": "24.1.0",
+    "tslint": "5.20.0",
     "tslint-config-prettier": "1.18.x",
     "tslint-config-stoplight": "1.3.x",
     "tslint-plugin-prettier": "2.0.x",
-    "typescript": "3.6.2"
+    "typescript": "3.6.3"
   },
   "lint-staged": {
     "src/**/*.ts": [

--- a/src/oas2/__tests__/accessors.test.ts
+++ b/src/oas2/__tests__/accessors.test.ts
@@ -216,11 +216,6 @@ describe('accessors', () => {
   });
 
   describe('getProduces', () => {
-    test('given all empty arrays should return asterisk', () => {
-      expect(getProduces({}, {})).toEqual(['*/*']);
-      expect(getProduces({ produces: [] }, { produces: [] })).toEqual(['*/*']);
-    });
-
     test('should fallback to spec produces', () => {
       expect(getProduces({ produces: ['text/plain'] }, {})).toEqual(['text/plain']);
     });
@@ -231,11 +226,6 @@ describe('accessors', () => {
   });
 
   describe('getConsumes', () => {
-    test('given all empty arrays should return asterisk', () => {
-      expect(getConsumes({}, {})).toEqual(['*/*']);
-      expect(getConsumes({ consumes: [] }, { consumes: [] })).toEqual(['*/*']);
-    });
-
     test('should fallback to spec consumes', () => {
       expect(getConsumes({ consumes: ['text/plain'] }, {})).toEqual(['text/plain']);
     });

--- a/src/oas2/__tests__/accessors.test.ts
+++ b/src/oas2/__tests__/accessors.test.ts
@@ -216,6 +216,11 @@ describe('accessors', () => {
   });
 
   describe('getProduces', () => {
+    test('given all empty arrays should return an empty array', () => {
+      expect(getProduces({}, {})).toEqual([]);
+      expect(getProduces({ produces: [] }, { produces: [] })).toEqual([]);
+    });
+
     test('should fallback to spec produces', () => {
       expect(getProduces({ produces: ['text/plain'] }, {})).toEqual(['text/plain']);
     });
@@ -226,6 +231,11 @@ describe('accessors', () => {
   });
 
   describe('getConsumes', () => {
+    test('given all empty arrays should return an empty array', () => {
+      expect(getConsumes({}, {})).toEqual([]);
+      expect(getConsumes({ consumes: [] }, { consumes: [] })).toEqual([]);
+    });
+
     test('should fallback to spec consumes', () => {
       expect(getConsumes({ consumes: ['text/plain'] }, {})).toEqual(['text/plain']);
     });

--- a/src/oas2/accessors.ts
+++ b/src/oas2/accessors.ts
@@ -43,5 +43,5 @@ function getSecurity(
 
 function getProducesOrConsumes(which: 'produces' | 'consumes', spec: Partial<Spec>, operation: Partial<Operation>) {
   const mimeTypes = get(operation, which, get(spec, which, [])) as string[];
-  return mimeTypes.length ? mimeTypes : ['*/*'];
+  return mimeTypes;
 }

--- a/src/oas2/index.ts
+++ b/src/oas2/index.ts
@@ -1,2 +1,2 @@
-export { computeOas2Operations, transformOas2Operation } from './operation';
+export { transformOas2Operation } from './operation';
 export { transformOas2Service } from './service';

--- a/src/oas2/operation.ts
+++ b/src/oas2/operation.ts
@@ -1,6 +1,6 @@
-import { DeepPartial, IHttpOperation } from '@stoplight/types';
+import { IHttpOperation } from '@stoplight/types';
 import { get, isNil, omitBy } from 'lodash';
-import { Operation, Parameter, Path, Response, Spec } from 'swagger-schema-official';
+import { Operation, Parameter, Path, Response } from 'swagger-schema-official';
 
 import { getOasParameters } from '../oas/accessors';
 import { translateToTags } from '../oas/tag';
@@ -10,11 +10,6 @@ import { translateToRequest } from './transformers/request';
 import { translateToResponses } from './transformers/responses';
 import { translateToSecurities } from './transformers/securities';
 import { translateToServers } from './transformers/servers';
-
-// TODO
-export function computeOas2Operations(spec: DeepPartial<Spec>): IHttpOperation[] {
-  return [];
-}
 
 export const transformOas2Operation: Oas2HttpOperationTransformer = ({ document, path, method }) => {
   const pathObj = get(document, ['paths', path]) as Path;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2437,6 +2437,11 @@ diff@^3.2.0:
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
+diff@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.1.tgz#0c667cb467ebbb5cea7f14f135cc2dba7780a8ff"
+  integrity sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==
+
 dir-glob@^2.0.0, dir-glob@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.2.2.tgz#fa09f0694153c8918b18ba0deafae94769fc50c4"
@@ -5009,6 +5014,11 @@ lodash.map@^4.5.1:
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
   integrity sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=
 
+lodash.memoize@4.x:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+  integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
 lodash.set@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
@@ -5666,10 +5676,10 @@ node-pre-gyp@^0.12.0:
     semver "^5.3.0"
     tar "^4"
 
-nodemon@1.x.x:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-1.19.1.tgz#576f0aad0f863aabf8c48517f6192ff987cd5071"
-  integrity sha512-/DXLzd/GhiaDXXbGId5BzxP1GlsqtMGM9zTmkWrgXtSqjKmGSbLicM/oAy4FR0YWm14jCHRwnR31AHS2dYFHrg==
+nodemon@1.19.2:
+  version "1.19.2"
+  resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-1.19.2.tgz#b0975147dc99b3761ceb595b3f9277084931dcc0"
+  integrity sha512-hRLYaw5Ihyw9zK7NF+9EUzVyS6Cvgc14yh8CAYr38tPxJa6UrOxwAQ351GwrgoanHCF0FalQFn6w5eoX/LGdJw==
   dependencies:
     chokidar "^2.1.5"
     debug "^3.1.0"
@@ -8133,15 +8143,16 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
-ts-jest@24.x.x:
-  version "24.0.2"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-24.0.2.tgz#8dde6cece97c31c03e80e474c749753ffd27194d"
-  integrity sha512-h6ZCZiA1EQgjczxq+uGLXQlNgeg02WWJBbeT8j6nyIBRQdglqbvzDoHahTEIiS6Eor6x8mK6PfZ7brQ9Q6tzHw==
+ts-jest@24.1.0:
+  version "24.1.0"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-24.1.0.tgz#2eaa813271a2987b7e6c3fefbda196301c131734"
+  integrity sha512-HEGfrIEAZKfu1pkaxB9au17b1d9b56YZSqz5eCVE8mX68+5reOvlM93xGOzzCREIov9mdH7JBG+s0UyNAqr0tQ==
   dependencies:
     bs-logger "0.x"
     buffer-from "1.x"
     fast-json-stable-stringify "2.x"
     json5 "2.x"
+    lodash.memoize "4.x"
     make-error "1.x"
     mkdirp "0.x"
     resolve "1.x"
@@ -8205,16 +8216,16 @@ tslint@5.11.x:
     tslib "^1.8.0"
     tsutils "^2.27.2"
 
-tslint@5.19.0:
-  version "5.19.0"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.19.0.tgz#a2cbd4a7699386da823f6b499b8394d6c47bb968"
-  integrity sha512-1LwwtBxfRJZnUvoS9c0uj8XQtAnyhWr9KlNvDIdB+oXyT+VpsOAaEhEgKi1HrZ8rq0ki/AAnbGSv4KM6/AfVZw==
+tslint@5.20.0:
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.20.0.tgz#fac93bfa79568a5a24e7be9cdde5e02b02d00ec1"
+  integrity sha512-2vqIvkMHbnx8acMogAERQ/IuINOq6DFqgF8/VDvhEkBqQh/x6SP0Y+OHnKth9/ZcHQSroOZwUQSN18v8KKF0/g==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     builtin-modules "^1.1.1"
     chalk "^2.3.0"
     commander "^2.12.1"
-    diff "^3.2.0"
+    diff "^4.0.1"
     glob "^7.1.1"
     js-yaml "^3.13.1"
     minimatch "^3.0.4"
@@ -8298,10 +8309,10 @@ typescript@3.2.x:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
   integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
 
-typescript@3.6.2:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.2.tgz#105b0f1934119dde543ac8eb71af3a91009efe54"
-  integrity sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==
+typescript@3.6.3:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
+  integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
 
 uglify-js@^3.1.4:
   version "3.6.0"


### PR DESCRIPTION
For some reason that I can't really remember OAS2 produces consumes default to `*/*`, even if the document has nothing in it.

On the other hand, in OAS3 this default mechanism is not a thing. This discrepancy is giving us troubles in Prism since we need to write special code to accomplish the same thing.

Unfortunately we lost the history because of the new repository — but if anybody recalls the reason, please speak up. Otherwise, this will uniform the behaviour between oas2 and 3.