### PR TITLE
feat: oas3 callbacks support

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@stoplight/json": "^3.1.1",
-    "@stoplight/types": "^11.1.0",
+    "@stoplight/types": "^11.2.0",
     "@types/swagger-schema-official": "~2.0.18",
     "@types/urijs": "~1.19.1",
     "lodash": "^4.17.15",

--- a/src/oas3/__tests__/__snapshots__/operation.test.ts.snap
+++ b/src/oas3/__tests__/__snapshots__/operation.test.ts.snap
@@ -156,22 +156,7 @@ Object {
   "path": "/users/{userId}",
   "request": Object {
     "body": Object {
-      "contents": Array [
-        Object {
-          "encodings": Array [],
-          "examples": Array [],
-          "mediaType": "application/json",
-          "schema": Object {
-            "$schema": "http://json-schema.org/draft-04/schema#",
-            "properties": Object {
-              "id": "string",
-            },
-            "type": "object",
-          },
-        },
-      ],
-      "description": undefined,
-      "required": undefined,
+      "contents": Array [],
     },
     "cookie": Array [],
     "headers": Array [],

--- a/src/oas3/__tests__/__snapshots__/operation.test.ts.snap
+++ b/src/oas3/__tests__/__snapshots__/operation.test.ts.snap
@@ -1,5 +1,64 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`transformOas3Operation callback 1`] = `
+Object {
+  "callbacks": Array [
+    Object {
+      "callbackName": "myCallback",
+      "id": "?http-operation-id?",
+      "iid": "cbId",
+      "method": "post",
+      "path": "http://prism.com?transactionId={$request.body#/id}",
+      "request": Object {
+        "body": Object {
+          "contents": Array [],
+        },
+        "cookie": Array [],
+        "headers": Array [],
+        "path": Array [],
+        "query": Array [],
+      },
+      "responses": Array [],
+      "security": Array [],
+      "servers": Array [],
+      "tags": Array [],
+    },
+  ],
+  "id": "?http-operation-id?",
+  "iid": "opid",
+  "method": "post",
+  "path": "/subscribe",
+  "request": Object {
+    "body": Object {
+      "contents": Array [
+        Object {
+          "encodings": Array [],
+          "examples": Array [],
+          "mediaType": "application/json",
+          "schema": Object {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "properties": Object {
+              "id": "string",
+            },
+            "type": "object",
+          },
+        },
+      ],
+      "description": undefined,
+      "required": undefined,
+    },
+    "cookie": Array [],
+    "headers": Array [],
+    "path": Array [],
+    "query": Array [],
+  },
+  "responses": Array [],
+  "security": Array [],
+  "servers": Array [],
+  "tags": Array [],
+}
+`;
+
 exports[`transformOas3Operation given no tags should translate operation with empty tags array 1`] = `
 Object {
   "deprecated": true,

--- a/src/oas3/__tests__/__snapshots__/operation.test.ts.snap
+++ b/src/oas3/__tests__/__snapshots__/operation.test.ts.snap
@@ -38,11 +38,10 @@ Object {
           "schema": Object {
             "$schema": "http://json-schema.org/draft-04/schema#",
             "properties": Object {
-              "id": "string",
+              "id": Object {
+                "type": "string",
+              },
             },
-            "required": Array [
-              "id",
-            ],
             "type": "object",
           },
         },

--- a/src/oas3/__tests__/__snapshots__/operation.test.ts.snap
+++ b/src/oas3/__tests__/__snapshots__/operation.test.ts.snap
@@ -8,7 +8,7 @@ Object {
       "id": "?http-operation-id?",
       "iid": "cbId",
       "method": "post",
-      "path": "http://prism.com?transactionId={$request.body#/id}",
+      "path": "http://example.com?transactionId={$request.body#/id}",
       "request": Object {
         "body": Object {
           "contents": Array [],

--- a/src/oas3/__tests__/__snapshots__/operation.test.ts.snap
+++ b/src/oas3/__tests__/__snapshots__/operation.test.ts.snap
@@ -40,6 +40,9 @@ Object {
             "properties": Object {
               "id": "string",
             },
+            "required": Array [
+              "id",
+            ],
             "type": "object",
           },
         },

--- a/src/oas3/__tests__/__snapshots__/operation.test.ts.snap
+++ b/src/oas3/__tests__/__snapshots__/operation.test.ts.snap
@@ -156,7 +156,22 @@ Object {
   "path": "/users/{userId}",
   "request": Object {
     "body": Object {
-      "contents": Array [],
+      "contents": Array [
+        Object {
+          "encodings": Array [],
+          "examples": Array [],
+          "mediaType": "application/json",
+          "schema": Object {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "properties": Object {
+              "id": "string",
+            },
+            "type": "object",
+          },
+        },
+      ],
+      "description": undefined,
+      "required": undefined,
     },
     "cookie": Array [],
     "headers": Array [],

--- a/src/oas3/__tests__/operation.test.ts
+++ b/src/oas3/__tests__/operation.test.ts
@@ -168,9 +168,10 @@ describe('transformOas3Operation', () => {
                       schema: {
                         type: 'object',
                         properties: {
-                          id: 'string',
+                          id: {
+                            type: 'string',
+                          },
                         },
-                        required: ['id'],
                       },
                     },
                   },

--- a/src/oas3/__tests__/operation.test.ts
+++ b/src/oas3/__tests__/operation.test.ts
@@ -176,7 +176,7 @@ describe('transformOas3Operation', () => {
                 },
                 callbacks: {
                   myCallback: {
-                    'http://prism.com?transactionId={$request.body#/id}': {
+                    'http://example.com?transactionId={$request.body#/id}': {
                       post: {
                         operationId: 'cbId',
                         responses: {},

--- a/src/oas3/__tests__/operation.test.ts
+++ b/src/oas3/__tests__/operation.test.ts
@@ -54,18 +54,6 @@ describe('transformOas3Operation', () => {
                 description: 'descr',
                 summary: 'summary',
                 tags: ['tag1'],
-                requestBody: {
-                  content: {
-                    'application/json': {
-                      schema: {
-                        type: 'object',
-                        properties: {
-                          id: 'string',
-                        },
-                      },
-                    },
-                  },
-                },
               },
             },
           },

--- a/src/oas3/__tests__/operation.test.ts
+++ b/src/oas3/__tests__/operation.test.ts
@@ -170,6 +170,7 @@ describe('transformOas3Operation', () => {
                         properties: {
                           id: 'string',
                         },
+                        required: ['id'],
                       },
                     },
                   },

--- a/src/oas3/__tests__/operation.test.ts
+++ b/src/oas3/__tests__/operation.test.ts
@@ -54,6 +54,18 @@ describe('transformOas3Operation', () => {
                 description: 'descr',
                 summary: 'summary',
                 tags: ['tag1'],
+                requestBody: {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'object',
+                        properties: {
+                          id: 'string',
+                        },
+                      },
+                    },
+                  },
+                },
               },
             },
           },

--- a/src/oas3/__tests__/operation.test.ts
+++ b/src/oas3/__tests__/operation.test.ts
@@ -145,4 +145,50 @@ describe('transformOas3Operation', () => {
       }),
     ).toMatchSnapshot();
   });
+
+  test('callback', () => {
+    expect(
+      transformOas3Operation({
+        path: '/subscribe',
+        method: 'post',
+        document: {
+          openapi: '3',
+          info: {
+            title: 'title',
+            version: '2',
+          },
+          paths: {
+            '/subscribe': {
+              post: {
+                operationId: 'opid',
+                responses: {},
+                requestBody: {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'object',
+                        properties: {
+                          id: 'string',
+                        },
+                      },
+                    },
+                  },
+                },
+                callbacks: {
+                  myCallback: {
+                    'http://prism.com?transactionId={$request.body#/id}': {
+                      post: {
+                        operationId: 'cbId',
+                        responses: {},
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }),
+    ).toMatchSnapshot();
+  });
 });

--- a/src/oas3/operation.ts
+++ b/src/oas3/operation.ts
@@ -42,7 +42,7 @@ export const transformOas3Operation: Oas3HttpOperationTransformer = ({ document,
       getOasParameters(operation.parameters as ParameterObject[], pathObj.parameters),
       operation.requestBody as RequestBodyObject,
     ),
-    callbacks: translateToCallbacks(operation.callbacks),
+    callbacks: translateToCallbacks(operation.callbacks || {}),
     tags: translateToTags(operation.tags || []),
     security: translateToSecurities(getSecurities(document, operation)),
   };

--- a/src/oas3/operation.ts
+++ b/src/oas3/operation.ts
@@ -6,6 +6,7 @@ import { getOasParameters } from '../oas/accessors';
 import { translateToTags } from '../oas/tag';
 import { Oas3HttpOperationTransformer } from '../oas/types';
 import { getSecurities } from './accessors';
+import { translateToCallbacks } from './transformers/callbacks';
 import { translateToRequest } from './transformers/request';
 import { translateToResponses } from './transformers/responses';
 import { translateToSecurities } from './transformers/securities';
@@ -41,6 +42,7 @@ export const transformOas3Operation: Oas3HttpOperationTransformer = ({ document,
       getOasParameters(operation.parameters as ParameterObject[], pathObj.parameters),
       operation.requestBody as RequestBodyObject,
     ),
+    callbacks: translateToCallbacks(operation.callbacks),
     tags: translateToTags(operation.tags || []),
     security: translateToSecurities(getSecurities(document, operation)),
   };

--- a/src/oas3/operation.ts
+++ b/src/oas3/operation.ts
@@ -42,7 +42,7 @@ export const transformOas3Operation: Oas3HttpOperationTransformer = ({ document,
       getOasParameters(operation.parameters as ParameterObject[], pathObj.parameters),
       operation.requestBody as RequestBodyObject,
     ),
-    callbacks: translateToCallbacks(operation.callbacks || {}),
+    callbacks: operation.callbacks && translateToCallbacks(operation.callbacks),
     tags: translateToTags(operation.tags || []),
     security: translateToSecurities(getSecurities(document, operation)),
   };

--- a/src/oas3/transformers/callbacks.ts
+++ b/src/oas3/transformers/callbacks.ts
@@ -2,10 +2,11 @@ import { IHttpCallbackOperation } from '@stoplight/types';
 import { CallbacksObject } from 'openapi3-ts';
 import { transformOas3Operation } from '../operation';
 
-export function translateToCallbacks(callbacks?: CallbacksObject): IHttpCallbackOperation[] | undefined {
-  if (!callbacks) return;
+export function translateToCallbacks(callbacks: CallbacksObject): IHttpCallbackOperation[] | undefined {
+  const entries = Object.entries(callbacks);
+  if (!entries.length) return;
 
-  return Object.entries(callbacks).reduce((results: IHttpCallbackOperation[], [callbackName, path2Methods]) => {
+  return entries.reduce((results: IHttpCallbackOperation[], [callbackName, path2Methods]) => {
     for (const [path, method2Op] of Object.entries(path2Methods)) {
       for (const [method, op] of Object.entries(method2Op as { [key: string]: {} })) {
         results.push({

--- a/src/oas3/transformers/callbacks.ts
+++ b/src/oas3/transformers/callbacks.ts
@@ -1,0 +1,28 @@
+import { IHttpCallbackOperation } from '@stoplight/types';
+import { CallbacksObject } from 'openapi3-ts';
+import { transformOas3Operation } from '../operation';
+
+export function translateToCallbacks(callbacks?: CallbacksObject): IHttpCallbackOperation[] | undefined {
+  if (!callbacks) return;
+
+  return Object.entries(callbacks).reduce((results: IHttpCallbackOperation[], [callbackName, path2Methods]) => {
+    for (const [path, method2Op] of Object.entries(path2Methods)) {
+      for (const [method, op] of Object.entries(method2Op as { [key: string]: {} })) {
+        results.push({
+          ...transformOas3Operation({
+            document: {
+              openapi: '3',
+              info: { title: '', version: '1' },
+              paths: { [path]: { [method]: op } },
+            },
+            method,
+            path,
+          }),
+          callbackName,
+        });
+      }
+    }
+
+    return results;
+  }, []);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -843,10 +843,10 @@
   dependencies:
     "@types/json-schema" "^7.0.3"
 
-"@stoplight/types@^11.1.0":
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/@stoplight/types/-/types-11.1.0.tgz#b29ecd8c8ad27bb564c7820c99f93c27f1d11bf1"
-  integrity sha512-z4VqnYIDTcj9R0f8AIDitBWkiAKKJ4W/Z5GJz/3fnBZBa/TD9Oak0xHbicXFXUvqTVCv/7D32PjPYiUX6W/EfQ==
+"@stoplight/types@^11.2.0":
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/@stoplight/types/-/types-11.2.0.tgz#1f9c9c6dcf481f21e68a01cfa6e81b1ea41d4faa"
+  integrity sha512-c4zMAaf+NusHxcfruYDnzBwX3VJ8h1E6KYW/11QqmtsmE+ua3tKYL3PNbrzWh7nz/Vmv0U8zoYMw42F1XxylaA==
   dependencies:
     "@types/json-schema" "^7.0.3"
 


### PR DESCRIPTION
Introduces a capability for reading callbacks from OASv3 specs. Needs https://github.com/stoplightio/types/pull/54 to be merged first (types).

The motivation behind extending the IHttpOperation interface: callbacks in OASv3 spec are wrapped in an object with callback name as property and operation as value. SL's way of representing such objects is to convert it to an array and add a property inside with the key name (see operations array, examples array, etc.). This change is compatible with that approach.

**Master PR**: https://github.com/stoplightio/prism/pull/716
**Related issue**: https://github.com/stoplightio/prism/issues/331
**The spec**: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#callbackObject
**Callback example**: https://github.com/OAI/OpenAPI-Specification/blob/master/examples/v3.0/callback-example.yaml