### PR TITLE
Preserve readOnly, writeOnly, xml and externalDocs in schemas

### DIFF
--- a/src/oas2/transformers/__tests__/params.test.ts
+++ b/src/oas2/transformers/__tests__/params.test.ts
@@ -78,6 +78,27 @@ describe('params.translator', () => {
       ).toMatchSnapshot();
     });
 
+    test('should preserve readOnly flag in schema', () => {
+      expect(
+        translateToBodyParameter(
+          {
+            in: 'body',
+            name: 'name',
+            required: true,
+            description: 'descr',
+            schema: {
+              readOnly: true,
+            },
+          },
+          consumes,
+        ),
+      ).toEqual(
+        expect.objectContaining({
+          contents: expect.arrayContaining([expect.objectContaining({ schema: { readOnly: true } })]),
+        }),
+      );
+    });
+
     test('given x-examples should translate to body parameter with multiple examples', () => {
       expect(
         translateToBodyParameter(

--- a/src/oas2/transformers/params.ts
+++ b/src/oas2/transformers/params.ts
@@ -59,14 +59,11 @@ export function translateToHeaderParam(parameter: HeaderParameter): IHttpHeaderP
 }
 
 export function translateToHeaderParams(headers: { [headerName: string]: Header }): IHttpHeaderParam[] {
-  return map(headers, (header, name) => {
-    const param: IHttpHeaderParam = {
-      ...buildSchemaForParameter(Object.assign({ name }, header)),
-      name,
-      style: HttpParamStyles.Simple,
-    };
-    return param;
-  });
+  return map(headers, (header, name) => ({
+    ...buildSchemaForParameter(Object.assign({ name }, header)),
+    name,
+    style: HttpParamStyles.Simple,
+  }));
 }
 
 export function translateToBodyParameter(body: BodyParameter, consumes: string[]): IHttpOperationRequestBody {
@@ -179,7 +176,7 @@ export function translateToPathParameter(parameter: PathParameter): IHttpPathPar
 }
 
 function buildSchemaForParameter(
-  param: (QueryParameter | PathParameter | HeaderParameter | FormDataParameter | Header) & { readOnly?: boolean },
+  param: QueryParameter | PathParameter | HeaderParameter | FormDataParameter | Header,
 ): { schema: JSONSchema4 | JSONSchema6 | JSONSchema7; description?: string } {
   const schema: Schema = pick(
     param,
@@ -200,7 +197,6 @@ function buildSchemaForParameter(
     'pattern',
     'uniqueItems',
     'multipleOf',
-    'readOnly',
   );
 
   if ('allowEmptyValue' in param && param.allowEmptyValue === false) {

--- a/src/oas2/transformers/params.ts
+++ b/src/oas2/transformers/params.ts
@@ -179,7 +179,7 @@ export function translateToPathParameter(parameter: PathParameter): IHttpPathPar
 }
 
 function buildSchemaForParameter(
-  param: QueryParameter | PathParameter | HeaderParameter | FormDataParameter | Header,
+  param: (QueryParameter | PathParameter | HeaderParameter | FormDataParameter | Header) & { readOnly?: boolean },
 ): { schema: JSONSchema4 | JSONSchema6 | JSONSchema7; description?: string } {
   const schema: Schema = pick(
     param,

--- a/src/oas2/transformers/params.ts
+++ b/src/oas2/transformers/params.ts
@@ -200,6 +200,7 @@ function buildSchemaForParameter(
     'pattern',
     'uniqueItems',
     'multipleOf',
+    'readOnly',
   );
 
   if ('allowEmptyValue' in param && param.allowEmptyValue === false) {

--- a/src/oas3/transformers/__tests__/content.test.ts
+++ b/src/oas3/transformers/__tests__/content.test.ts
@@ -168,6 +168,10 @@ describe('translateMediaTypeObject', () => {
       description: 'A simple string',
       example: 'hello',
       deprecated: true,
+      writeOnly: true,
+      readOnly: true,
+      externalDocs: { url: 'http://example.com/docs', description: 'Shiny docs' },
+      xml: {},
     };
 
     const originalSchema = JSON.parse(JSON.stringify(schema));
@@ -206,6 +210,53 @@ describe('translateMediaTypeObject', () => {
         'mediaType',
       );
       expect(translatedObject.schema).toHaveProperty('deprecated', true);
+    });
+
+    test('will keep the writeOnly property', () => {
+      const translatedObject = translateMediaTypeObject(
+        {
+          schema,
+          encoding: {},
+        },
+        'mediaType',
+      );
+      expect(translatedObject.schema).toHaveProperty('writeOnly', true);
+    });
+
+    test('will keep the readOnly property', () => {
+      const translatedObject = translateMediaTypeObject(
+        {
+          schema,
+          encoding: {},
+        },
+        'mediaType',
+      );
+      expect(translatedObject.schema).toHaveProperty('readOnly', true);
+    });
+
+    test('will keep the xml property', () => {
+      const translatedObject = translateMediaTypeObject(
+        {
+          schema,
+          encoding: {},
+        },
+        'mediaType',
+      );
+      expect(translatedObject.schema).toHaveProperty('xml', {});
+    });
+
+    test('will keep the externalDocs property', () => {
+      const translatedObject = translateMediaTypeObject(
+        {
+          schema,
+          encoding: {},
+        },
+        'mediaType',
+      );
+      expect(translatedObject.schema).toHaveProperty('externalDocs', {
+        url: 'http://example.com/docs',
+        description: 'Shiny docs',
+      });
     });
   });
 });

--- a/src/oas3/transformers/__tests__/content.test.ts
+++ b/src/oas3/transformers/__tests__/content.test.ts
@@ -175,84 +175,40 @@ describe('translateMediaTypeObject', () => {
     };
 
     const originalSchema = JSON.parse(JSON.stringify(schema));
+    const translatedObject = translateMediaTypeObject(
+      {
+        schema,
+        example: 'hey',
+        encoding: {},
+      },
+      'mediaType',
+    );
 
     test('will not modify the original schema so it can be reused in references ', () => {
-      translateMediaTypeObject(
-        {
-          schema,
-          example: 'hey',
-          encoding: {},
-        },
-        'mediaType',
-      );
-
       expect(schema).toStrictEqual(originalSchema);
     });
 
     test('will keep the example property', () => {
-      const translatedObject = translateMediaTypeObject(
-        {
-          schema,
-          example: 'hey',
-          encoding: {},
-        },
-        'mediaType',
-      );
       expect(translatedObject.schema).toHaveProperty('example', 'hello');
     });
 
     test('will keep the deprecated property', () => {
-      const translatedObject = translateMediaTypeObject(
-        {
-          schema,
-          encoding: {},
-        },
-        'mediaType',
-      );
       expect(translatedObject.schema).toHaveProperty('deprecated', true);
     });
 
     test('will keep the writeOnly property', () => {
-      const translatedObject = translateMediaTypeObject(
-        {
-          schema,
-          encoding: {},
-        },
-        'mediaType',
-      );
       expect(translatedObject.schema).toHaveProperty('writeOnly', true);
     });
 
     test('will keep the readOnly property', () => {
-      const translatedObject = translateMediaTypeObject(
-        {
-          schema,
-          encoding: {},
-        },
-        'mediaType',
-      );
       expect(translatedObject.schema).toHaveProperty('readOnly', true);
     });
 
     test('will keep the xml property', () => {
-      const translatedObject = translateMediaTypeObject(
-        {
-          schema,
-          encoding: {},
-        },
-        'mediaType',
-      );
       expect(translatedObject.schema).toHaveProperty('xml', {});
     });
 
     test('will keep the externalDocs property', () => {
-      const translatedObject = translateMediaTypeObject(
-        {
-          schema,
-          encoding: {},
-        },
-        'mediaType',
-      );
       expect(translatedObject.schema).toHaveProperty('externalDocs', {
         url: 'http://example.com/docs',
         description: 'Shiny docs',

--- a/src/oas3/transformers/content.ts
+++ b/src/oas3/transformers/content.ts
@@ -114,7 +114,7 @@ export function translateMediaTypeObject(
       ? (toJsonSchema(schema, {
           cloneSchema: true,
           strictMode: false,
-          keepNotSupported: ['example', 'deprecated'],
+          keepNotSupported: ['example', 'deprecated', 'readOnly', 'writeOnly', 'xml', 'externalDocs'],
         }) as JSONSchema4)
       : undefined,
     // Note that I'm assuming all references are resolved


### PR DESCRIPTION
Add support for unsupported schema properties: `readOnly, writeOnly, xml and externalDocs`