### PR TITLE
fix: include schema in parameter check

### DIFF
--- a/src/oas3/guards.ts
+++ b/src/oas3/guards.ts
@@ -26,6 +26,7 @@ export const isBaseParameterObject = (
     'style' in maybeBaseParameterObject ||
     'examples' in maybeBaseParameterObject ||
     'example' in maybeBaseParameterObject ||
+    'schema' in maybeBaseParameterObject ||
     'name' in maybeBaseParameterObject);
 
 export const isHeaderObject = (maybeHeaderObject: unknown): maybeHeaderObject is HeaderObject =>


### PR DESCRIPTION
Addresses: https://github.com/stoplightio/studio-internal/issues/1448#event-2895785126

Newly added response header wasn't treated as oas3 header when building virtual node

Changes:
- include `schema` when checking if object is Parameter (Header)