### PR TITLE
fix: override definition scopes with operation scopes

### DIFF
--- a/src/oas2/__tests__/__snapshots__/operation.test.ts.snap
+++ b/src/oas2/__tests__/__snapshots__/operation.test.ts.snap
@@ -45,7 +45,7 @@ Object {
           "implicit": Object {
             "authorizationUrl": "https://petstore.swagger.io/oauth/dialog",
             "scopes": Object {
-              "write:pets": "",
+              "write:pets": "modify pets in your account",
             },
           },
         },

--- a/src/oas2/__tests__/__snapshots__/operation.test.ts.snap
+++ b/src/oas2/__tests__/__snapshots__/operation.test.ts.snap
@@ -45,8 +45,7 @@ Object {
           "implicit": Object {
             "authorizationUrl": "https://petstore.swagger.io/oauth/dialog",
             "scopes": Object {
-              "read:pets": "read your pets",
-              "write:pets": "modify pets in your account",
+              "write:pets": "",
             },
           },
         },

--- a/src/oas2/__tests__/accessors.test.ts
+++ b/src/oas2/__tests__/accessors.test.ts
@@ -52,8 +52,8 @@ describe('accessors', () => {
               authorizationUrl: 'http://swagger.io/api/oauth/dialog',
               flow: 'implicit',
               scopes: {
-                'read:pets': '',
-                'write:pets': '',
+                'write:pets': 'modify pets in your account',
+                'read:pets': 'read your pets',
               },
               type: 'oauth2',
               key: 'petstore_auth',
@@ -88,8 +88,8 @@ describe('accessors', () => {
               authorizationUrl: 'http://swagger.io/api/oauth/dialog',
               flow: 'implicit',
               scopes: {
-                'read:pets': '',
-                'write:pets': '',
+                'write:pets': 'modify pets in your account',
+                'read:pets': 'read your pets',
               },
               type: 'oauth2',
               key: 'petstore_auth',
@@ -189,7 +189,7 @@ describe('accessors', () => {
           {
             authorizationUrl: 'http://swagger.io/api/oauth/dialog',
             flow: 'implicit',
-            scopes: { 'write:pets': '' },
+            scopes: { 'write:pets': 'modify pets in your account' },
             type: 'oauth2',
             key: 'petstore_auth',
           },
@@ -212,7 +212,10 @@ describe('accessors', () => {
           {
             authorizationUrl: 'http://swagger.io/api/oauth/dialog',
             flow: 'implicit',
-            scopes: { 'write:pets': '', 'read:pets': '' },
+            scopes: {
+              'write:pets': 'modify pets in your account',
+              'read:pets': 'read your pets',
+            },
             type: 'oauth2',
             key: 'petstore_auth',
           },

--- a/src/oas2/__tests__/accessors.test.ts
+++ b/src/oas2/__tests__/accessors.test.ts
@@ -52,8 +52,8 @@ describe('accessors', () => {
               authorizationUrl: 'http://swagger.io/api/oauth/dialog',
               flow: 'implicit',
               scopes: {
-                'read:pets': 'read your pets',
-                'write:pets': 'modify pets in your account',
+                'read:pets': '',
+                'write:pets': '',
               },
               type: 'oauth2',
               key: 'petstore_auth',
@@ -88,8 +88,8 @@ describe('accessors', () => {
               authorizationUrl: 'http://swagger.io/api/oauth/dialog',
               flow: 'implicit',
               scopes: {
-                'read:pets': 'read your pets',
-                'write:pets': 'modify pets in your account',
+                'read:pets': '',
+                'write:pets': '',
               },
               type: 'oauth2',
               key: 'petstore_auth',
@@ -189,7 +189,7 @@ describe('accessors', () => {
           {
             authorizationUrl: 'http://swagger.io/api/oauth/dialog',
             flow: 'implicit',
-            scopes: { 'read:pets': 'read your pets', 'write:pets': 'modify pets in your account' },
+            scopes: { 'write:pets': '' },
             type: 'oauth2',
             key: 'petstore_auth',
           },
@@ -212,7 +212,7 @@ describe('accessors', () => {
           {
             authorizationUrl: 'http://swagger.io/api/oauth/dialog',
             flow: 'implicit',
-            scopes: { 'write:pets': 'modify pets in your account', 'read:pets': 'read your pets' },
+            scopes: { 'write:pets': '', 'read:pets': '' },
             type: 'oauth2',
             key: 'petstore_auth',
           },

--- a/src/oas2/accessors.ts
+++ b/src/oas2/accessors.ts
@@ -1,5 +1,5 @@
 import { DeepPartial, Dictionary } from '@stoplight/types';
-import { compact, get, isArray, isEmpty, isString, keys, map, merge } from 'lodash';
+import { compact, get, isArray, isEmpty, isString, keys, map, merge, pickBy } from 'lodash';
 import { negate } from 'lodash/fp';
 import { BaseOAuthSecurity, OAuthScope, Operation, Security, Spec } from 'swagger-schema-official';
 import { isSecurityScheme } from './guards';
@@ -43,12 +43,9 @@ function getSecurity(
           const defCopy = merge<{ key: string }, Security>({ key }, def);
           const scopes = sec[key] || [];
 
-          // Override definition scopes with operation scopes
+          // Filter definition scopes by operation scopes
           if (defCopy.type === 'oauth2' && scopes.length) {
-            (defCopy as BaseOAuthSecurity).scopes = scopes.reduce(
-              (acc: OAuthScope, s: string) => ({ ...acc, [s]: '' }),
-              {},
-            );
+            defCopy.scopes = pickBy(defCopy.scopes, (_val, s: string) => scopes.includes(s));
           }
 
           return defCopy;


### PR DESCRIPTION
According to [OAS 2 spec](https://swagger.io/docs/specification/2-0/authentication):

> Global security can be overridden in individual operations to use a different authentication type, different OAuth 2 scopes, or no authentication at all.

This PR adds ability to override oauth2 definition scopes with an operation scopes and it should fix https://github.com/stoplightio/platform/issues/1599
