### PR TITLE
fix: enum OasVersion cannot be const

### DIFF
--- a/src/oas/types.ts
+++ b/src/oas/types.ts
@@ -2,7 +2,7 @@ import { DeepPartial, IHttpOperation, IHttpService } from '@stoplight/types';
 import { OpenAPIObject } from 'openapi3-ts';
 import { Spec } from 'swagger-schema-official';
 
-export const enum OasVersion {
+export enum OasVersion {
   OAS2 = 2,
   OAS3 = 3,
 }


### PR DESCRIPTION
Graphite references that enum.

Needed to make the graphite->platform switch.
https://github.com/stoplightio/graphite/blob/master/src/plugins/http/oas2.ts#L2
https://github.com/stoplightio/graphite/blob/master/src/plugins/http/oas3.ts#L2