### PR TITLE
Postman Collection: Types fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@types/jest": "24.0.25",
     "@types/json-schema": "7.0.x",
     "@types/lodash": "4.14.149",
-    "@types/postman-collection": "^3.0.3",
+    "@types/postman-collection": "^3.5.0",
     "jest": "24.9.0",
     "prettier": "1.19.1",
     "ts-jest": "24.3.0",

--- a/src/postman/__tests__/operation.test.ts
+++ b/src/postman/__tests__/operation.test.ts
@@ -1,4 +1,3 @@
-import { HeaderDefinition, RequestAuthDefinition, RequestBody, VariableDefinition } from 'postman-collection';
 import { transformPostmanCollectionOperation, transformPostmanCollectionOperations } from '../operation';
 
 describe('transformPostmanCollectionOperation()', () => {
@@ -13,8 +12,8 @@ describe('transformPostmanCollectionOperation()', () => {
                   request: {
                     method: 'get',
                     url: '/path/:param?a=b',
-                    body: { mode: 'raw', raw: 'test' } as RequestBody,
-                    header: [{ key: 'header', value: 'a header' }] as HeaderDefinition,
+                    body: { mode: 'raw', raw: 'test' },
+                    header: [{ key: 'header', value: 'a header' }],
                   },
                   description: 'desc',
                 },
@@ -59,11 +58,11 @@ describe('transformPostmanCollectionOperation()', () => {
                   request: {
                     method: 'get',
                     url: '/path',
-                    header: [{ key: 'content-type', value: 'application/json' }] as HeaderDefinition,
+                    header: [{ key: 'content-type', value: 'application/json' }],
                     body: {
                       mode: 'raw',
                       raw: '{}',
-                    } as RequestBody,
+                    },
                   },
                 },
               ],
@@ -157,7 +156,7 @@ describe('transformPostmanCollectionOperation()', () => {
                             type: 'string',
                           },
                         ],
-                      } as RequestAuthDefinition,
+                      },
                     },
                   },
                 ],
@@ -185,7 +184,7 @@ describe('transformPostmanCollectionOperation()', () => {
                     request: {
                       method: 'get',
                       url: '/path',
-                      auth: { type: 'nooauth' },
+                      auth: { type: 'noauth' },
                     },
                   },
                 ],
@@ -241,7 +240,7 @@ describe('transformPostmanCollectionOperation()', () => {
                   request: {
                     method: 'get',
                     url: 'https://{{hostvar}}/path',
-                    body: { mode: 'raw', raw: 'test{{bodyvar}}test' } as RequestBody,
+                    body: { mode: 'raw', raw: 'test{{bodyvar}}test' },
                   },
                 },
               ],
@@ -254,7 +253,7 @@ describe('transformPostmanCollectionOperation()', () => {
                   key: 'hostvar',
                   value: 'example.com',
                 },
-              ] as VariableDefinition,
+              ],
             },
             method: 'get',
             path: '/path',

--- a/src/postman/operation.ts
+++ b/src/postman/operation.ts
@@ -9,7 +9,7 @@ import {
   IHttpQueryParam,
   IMediaTypeContent,
 } from '@stoplight/types';
-import { Collection, CollectionDefinition, Item, ItemGroup, RequestAuth, Url } from 'postman-collection';
+import { Collection, CollectionDefinition, Item, RequestAuth, Url } from 'postman-collection';
 import { transformRequest } from './transformers/request';
 import { transformResponse } from './transformers/response';
 import {
@@ -27,9 +27,7 @@ export const transformPostmanCollectionOperations = (document: CollectionDefinit
   const securitySchemes = transformSecuritySchemes(collection);
   const operations: IHttpOperation[] = [];
 
-  ((collection as unknown) as ItemGroup<Item>).forEachItem(item =>
-    operations.push(transformItem(item, securitySchemes)),
-  );
+  collection.forEachItem(item => operations.push(transformItem(item, securitySchemes)));
 
   return operations;
 };
@@ -88,7 +86,7 @@ function transformItem(item: Item, securitySchemes: PostmanSecurityScheme[]): IH
 function findItem(collection: Collection, method: string, path: string): Item | undefined {
   let found;
 
-  ((collection as unknown) as ItemGroup<Item>).forEachItem(item => {
+  collection.forEachItem(item => {
     if (
       item.request.method.toLowerCase() === method.toLowerCase() &&
       getPath(item.request.url).toLowerCase() === path.toLowerCase()

--- a/src/postman/transformers/__tests__/params.test.ts
+++ b/src/postman/transformers/__tests__/params.test.ts
@@ -267,10 +267,6 @@ describe('transformBody()', () => {
           ],
         });
       });
-
-      it('returns no body', () => {
-        expect(transformBody(new RequestBody({ mode: 'formdata' }))).toBeUndefined();
-      });
     });
   });
 
@@ -345,10 +341,6 @@ describe('transformBody()', () => {
             },
           ],
         });
-      });
-
-      it('returns no body', () => {
-        expect(transformBody(new RequestBody({ mode: 'urlencoded' }))).toBeUndefined();
       });
     });
   });

--- a/src/postman/transformers/__tests__/params.test.ts
+++ b/src/postman/transformers/__tests__/params.test.ts
@@ -156,7 +156,7 @@ describe('transformBody()', () => {
           expect(
             transformBody(
               new RequestBody({
-                mode: 'formdata',
+                mode: RequestBody.MODES.formdata,
                 formdata: [
                   { key: 'k1', value: 'v1' },
                   { key: 'k2', value: 'v2', description: 'd2' },
@@ -213,7 +213,7 @@ describe('transformBody()', () => {
       it('returns body containing schema and example with generated keys', () => {
         const result = transformBody(
           new RequestBody({
-            mode: 'formdata',
+            mode: RequestBody.MODES.formdata,
             formdata: [{ value: 'v1' }, { value: 'v2', description: 'd2' }],
           }),
           'multipart/test+form-data',
@@ -269,7 +269,7 @@ describe('transformBody()', () => {
       });
 
       it('returns no body', () => {
-        expect(transformBody({ mode: 'formdata' } as RequestBody)).toBeUndefined();
+        expect(transformBody(new RequestBody({ mode: 'formdata' }))).toBeUndefined();
       });
     });
   });
@@ -348,14 +348,14 @@ describe('transformBody()', () => {
       });
 
       it('returns no body', () => {
-        expect(transformBody({ mode: 'urlencoded' } as RequestBody)).toBeUndefined();
+        expect(transformBody(new RequestBody({ mode: 'urlencoded' }))).toBeUndefined();
       });
     });
   });
 
   describe('body is passed in unknown mode', () => {
     it('returns no body', () => {
-      expect(transformBody({ mode: 'unknown' } as RequestBody)).toBeUndefined();
+      expect(transformBody(new RequestBody({ mode: 'unknown' }))).toBeUndefined();
     });
   });
 });

--- a/src/postman/transformers/__tests__/request.test.ts
+++ b/src/postman/transformers/__tests__/request.test.ts
@@ -1,5 +1,5 @@
 import { INodeExample } from '@stoplight/types';
-import { HeaderDefinition, Request, RequestBody } from 'postman-collection';
+import { Request } from 'postman-collection';
 import { transformRequest } from '../request';
 
 describe('transformRequest()', () => {
@@ -9,8 +9,8 @@ describe('transformRequest()', () => {
         new Request({
           method: 'get',
           url: '/path/:param?a=b',
-          body: { mode: 'raw', raw: 'test' } as RequestBody,
-          header: [{ key: 'header', value: 'a header' }] as HeaderDefinition,
+          body: { mode: 'raw', raw: 'test' },
+          header: [{ key: 'header', value: 'a header' }],
         }),
       ),
     ).toEqual({

--- a/src/postman/transformers/__tests__/securitySchemes.spec.ts
+++ b/src/postman/transformers/__tests__/securitySchemes.spec.ts
@@ -1,5 +1,5 @@
-import { HttpParamStyles } from '@stoplight/types/dist';
-import { Collection, HeaderDefinition, RequestAuth, RequestAuthDefinition, RequestBody } from 'postman-collection';
+import { HttpParamStyles } from '@stoplight/types';
+import { Collection, RequestAuth, RequestAuthDefinition } from 'postman-collection';
 import {
   isPostmanSecuritySchemeEqual,
   PostmanSecurityScheme,
@@ -26,7 +26,7 @@ describe('transformSecurityScheme()', () => {
                 type: 'string',
               },
             ],
-          } as RequestAuthDefinition),
+          }),
           type => `auth-${type}`,
         ),
       ).toEqual({
@@ -63,7 +63,7 @@ describe('transformSecurityScheme()', () => {
                 type: 'string',
               },
             ],
-          } as RequestAuthDefinition),
+          }),
           type => `auth-${type}`,
         ),
       ).toEqual({
@@ -128,7 +128,7 @@ describe('transformSecurityScheme()', () => {
                   type: 'string',
                 },
               ],
-            } as RequestAuthDefinition),
+            }),
             type => `auth-${type}`,
           ),
         ).toEqual({
@@ -161,7 +161,7 @@ describe('transformSecurityScheme()', () => {
                   type: 'string',
                 },
               ],
-            } as RequestAuthDefinition),
+            }),
             type => `auth-${type}`,
           ),
         ).toEqual({
@@ -200,7 +200,7 @@ describe('transformSecurityScheme()', () => {
               new RequestAuth({
                 type: 'oauth1',
                 oauth1: params(true, true),
-              } as RequestAuthDefinition),
+              }),
               type => `auth-${type}`,
             ),
           ).toEqual({
@@ -233,7 +233,7 @@ describe('transformSecurityScheme()', () => {
                 oauth1: params(true, true).filter(
                   ({ key }) => !['realm', 'timestamp', 'signatureMethod'].includes(key),
                 ),
-              } as RequestAuthDefinition),
+              }),
               type => `auth-${type}`,
             ),
           ).toEqual({
@@ -267,7 +267,7 @@ describe('transformSecurityScheme()', () => {
                 new RequestAuth({
                   type: 'oauth1',
                   oauth1: params(false, true),
-                } as RequestAuthDefinition),
+                }),
                 type => `auth-${type}`,
               ),
             ).toEqual({
@@ -310,7 +310,7 @@ describe('transformSecurityScheme()', () => {
                   oauth1: params(false, true).filter(
                     ({ key }) => !['version', 'timestamp', 'signatureMethod'].includes(key),
                   ),
-                } as RequestAuthDefinition),
+                }),
                 type => `auth-${type}`,
               ),
             ).toEqual({
@@ -352,7 +352,7 @@ describe('transformSecurityScheme()', () => {
               new RequestAuth({
                 type: 'oauth1',
                 oauth1: params(false, false),
-              } as RequestAuthDefinition),
+              }),
               type => `auth-${type}`,
             ),
           ).toEqual({
@@ -407,7 +407,7 @@ describe('transformSecurityScheme()', () => {
                   type: 'string',
                 },
               ],
-            } as RequestAuthDefinition),
+            }),
             type => `auth-${type}`,
           ),
         ).toEqual({
@@ -440,7 +440,7 @@ describe('transformSecurityScheme()', () => {
                   type: 'string',
                 },
               ],
-            } as RequestAuthDefinition),
+            }),
             type => `auth-${type}`,
           ),
         ).toEqual({
@@ -475,7 +475,7 @@ describe('transformSecurityScheme()', () => {
               { key: 'authId', value: 'HawkAuthId', type: 'string' },
               { key: 'algorithm', value: 'sha256', type: 'string' },
             ],
-          } as RequestAuthDefinition),
+          }),
           type => `auth-${type}`,
         ),
       ).toEqual({
@@ -509,7 +509,7 @@ describe('transformSecurityScheme()', () => {
               { key: 'secretKey', value: 'TestSecretKey', type: 'string' },
               { key: 'accessKey', value: 'TestAccessKey', type: 'string' },
             ],
-          } as RequestAuthDefinition),
+          }),
           type => `auth-${type}`,
         ),
       ).toEqual({
@@ -551,7 +551,7 @@ describe('transformSecurityScheme()', () => {
               { key: 'clientToken', value: 'TestClientToken', type: 'string' },
               { key: 'accessToken', value: 'TestAccessToken', type: 'string' },
             ],
-          } as RequestAuthDefinition),
+          }),
           type => `auth-${type}`,
         ),
       ).toEqual({
@@ -575,14 +575,12 @@ describe('transformSecurityScheme()', () => {
           new RequestAuth({
             type: 'ntlm',
             ntlm: [
-              [
-                { key: 'workstation', value: 'Karol-MacBook', type: 'string' },
-                { key: 'domain', value: 'example.com', type: 'string' },
-                { key: 'password', value: '1235', type: 'string' },
-                { key: 'username', value: 'Karol', type: 'string' },
-              ],
+              { key: 'workstation', value: 'Karol-MacBook', type: 'string' },
+              { key: 'domain', value: 'example.com', type: 'string' },
+              { key: 'password', value: '1235', type: 'string' },
+              { key: 'username', value: 'Karol', type: 'string' },
             ],
-          } as RequestAuthDefinition),
+          }),
           type => `auth-${type}`,
         ),
       ).toEqual({
@@ -604,14 +602,15 @@ describe('transformSecurityScheme()', () => {
   });
 
   it('ignores noauth', () => {
-    expect(
-      transformSecurityScheme(new RequestAuth({ type: 'noauth' } as RequestAuthDefinition), () => 'a'),
-    ).toBeUndefined();
+    expect(transformSecurityScheme(new RequestAuth({ type: 'noauth' }), () => 'a')).toBeUndefined();
   });
 
   it('ignores unknown auth type', () => {
     expect(
-      transformSecurityScheme(new RequestAuth({ type: 'non-existing-type' } as RequestAuthDefinition), () => 'a'),
+      transformSecurityScheme(
+        new RequestAuth(({ type: 'non-existing-type' } as unknown) as RequestAuthDefinition),
+        () => 'a',
+      ),
     ).toBeUndefined();
   });
 });

--- a/src/postman/transformers/params.ts
+++ b/src/postman/transformers/params.ts
@@ -107,7 +107,7 @@ function transformParamsBody<T extends FormParam | QueryParam>(
       },
       value: item.value,
     };
-  }, undefined);
+  });
 
   return {
     mediaType,

--- a/src/postman/transformers/response.ts
+++ b/src/postman/transformers/response.ts
@@ -1,4 +1,4 @@
-import { HttpParamStyles, IHttpHeaderParam, IHttpOperationResponse } from '@stoplight/types/dist';
+import { HttpParamStyles, IHttpHeaderParam, IHttpOperationResponse } from '@stoplight/types';
 import { Cookie, Response } from 'postman-collection';
 import { transformDescriptionDefinition } from '../util';
 import { transformHeader, transformRawBody } from './params';
@@ -16,10 +16,7 @@ export function transformResponse(response: Response): IHttpOperationResponse {
 }
 
 function transformCookie(cookie: Cookie): IHttpHeaderParam | undefined {
-  // @ts-ignore @todo fix typing bug in postman-collection
-  const name = cookie.name;
-
-  const params = [`${name || ''}=${cookie.value || ''}`];
+  const params = [`${cookie.name || ''}=${cookie.value || ''}`];
 
   if (cookie.expires) params.push(`Expires=${cookie.expires.toUTCString()}`);
   if (cookie.maxAge !== undefined) params.push(`Max-Age=${cookie.maxAge}`);

--- a/src/postman/transformers/securityScheme.ts
+++ b/src/postman/transformers/securityScheme.ts
@@ -1,6 +1,6 @@
 import { HttpParamStyles, HttpSecurityScheme, IHttpHeaderParam, IHttpQueryParam } from '@stoplight/types';
 import { isEqual, omit } from 'lodash';
-import { Collection, Item, ItemGroup, RequestAuth } from 'postman-collection';
+import { Collection, RequestAuth } from 'postman-collection';
 
 export type PostmanSecurityScheme = StandardSecurityScheme | QuerySecurityScheme | HeaderSecurityScheme;
 
@@ -243,7 +243,7 @@ export function transformSecuritySchemes(collection: Collection) {
     }
   }
 
-  ((collection as unknown) as ItemGroup<Item>).forEachItem(item => {
+  collection.forEachItem(item => {
     const auth = item.getAuth();
     if (auth) {
       const transformed = transformSecurityScheme(auth, type => `${type}-${securitySchemeIdx++}`);
@@ -251,7 +251,7 @@ export function transformSecuritySchemes(collection: Collection) {
     }
   });
 
-  ((collection as unknown) as ItemGroup<Item>).forEachItemGroup(itemGroup => {
+  collection.forEachItemGroup(itemGroup => {
     if (itemGroup.auth) {
       const transformed = transformSecurityScheme(itemGroup.auth, type => `${type}-${securitySchemeIdx++}`);
       if (transformed) addSecurityScheme(transformed);

--- a/yarn.lock
+++ b/yarn.lock
@@ -967,10 +967,10 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
-"@types/postman-collection@^3.0.3":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@types/postman-collection/-/postman-collection-3.0.3.tgz#192df46cdf7038b2834c1b915f3a28d7e9aeff09"
-  integrity sha512-sfEcie4g6LCixXnZ2qV1UE2+VrrmIJc8rXKFB2QmeGUm/DJwRiNK/YHduLEt5VkyQyprrhtXJR4dQNjPHC6dDg==
+"@types/postman-collection@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@types/postman-collection/-/postman-collection-3.5.0.tgz#474b1217563b2fcae918616e82c1796f27873845"
+  integrity sha512-sSHSaMHBBj7odnDhJn/XL+pcUU9t985ANDLtPBAlEjWE25SmRS3pN8k1UJzIxc+nhZ/kqG44pysmvAFjlIOLhg==
   dependencies:
     "@types/node" "*"
 


### PR DESCRIPTION
Postman-collection types are now fixed (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42582) so we no longer need explicit casts and other workarounds to get postman-collection transform work.

This PR removes unnecessary code.