### PR TITLE
Postman Collection cookie.expires fix

### DIFF
--- a/src/postman/transformers/__tests__/response.test.ts
+++ b/src/postman/transformers/__tests__/response.test.ts
@@ -305,6 +305,6 @@ describe('transformResponse()', () => {
           ],
         });
       });
-    })
+    });
   });
 });

--- a/src/postman/transformers/__tests__/response.test.ts
+++ b/src/postman/transformers/__tests__/response.test.ts
@@ -268,5 +268,43 @@ describe('transformResponse()', () => {
         });
       });
     });
+
+    describe('expires is defined as timestamp', () => {
+      it('creates correct Set-Cookie header', () => {
+        expect(
+          transformResponse(
+            new Response({
+              code: 200,
+              cookie: [
+                {
+                  key: 'eat',
+                  value: 'functions',
+                  domain: 'example.com',
+                  path: '/',
+                  expires: (1502442248 as unknown) as string, // @todo remove after postman-collection types fix
+                },
+              ],
+              responseTime: 100,
+            }),
+          ),
+        ).toEqual({
+          code: '200',
+          contents: undefined,
+          description: undefined,
+          headers: [
+            {
+              examples: [
+                {
+                  key: 'default',
+                  value: 'eat=functions; Expires=Fri, 11 Aug 2017 09:04:08 GMT; Domain=example.com; Path=/',
+                },
+              ],
+              name: 'set-cookie',
+              style: 'simple',
+            },
+          ],
+        });
+      });
+    })
   });
 });

--- a/src/postman/transformers/response.ts
+++ b/src/postman/transformers/response.ts
@@ -17,8 +17,9 @@ export function transformResponse(response: Response): IHttpOperationResponse {
 
 function transformCookie(cookie: Cookie): IHttpHeaderParam | undefined {
   const params = [`${cookie.name || ''}=${cookie.value || ''}`];
+  const expires = cookie.expires as Date | number | undefined; // @todo temporary until postman-collection types fixed
 
-  if (cookie.expires) params.push(`Expires=${cookie.expires.toUTCString()}`);
+  if (expires) params.push(`Expires=${(isDate(expires) ? expires : new Date(expires * 1000)).toUTCString()}`);
   if (cookie.maxAge !== undefined) params.push(`Max-Age=${cookie.maxAge}`);
   if (cookie.domain) params.push(`Domain=${cookie.domain}`);
   if (cookie.path) params.push(`Path=${cookie.path}`);
@@ -36,4 +37,8 @@ function transformCookie(cookie: Cookie): IHttpHeaderParam | undefined {
     ],
     style: HttpParamStyles.Simple,
   };
+}
+
+function isDate(date: Date | number): date is Date {
+  return date instanceof Date;
 }


### PR DESCRIPTION
PC typings state that `cookie.expires` is an `Date|undefined`. However an integer timestamp is also an accepted value:
- implementation: https://github.com/postmanlabs/postman-collection/blob/develop/lib/collection/cookie.js#L142
- example: https://github.com/postmanlabs/postman-collection/blob/develop/examples/collection-v2.json#L75

This PR prepares `http-spec` to handle such case.