### PR TITLE
Postman Collection: Merging IHttpOperations

### DIFF
--- a/src/__tests__/merge.test.ts
+++ b/src/__tests__/merge.test.ts
@@ -178,7 +178,10 @@ describe('mergeOperations()', () => {
             path: '/a',
             responses: [{ code: '200' }],
             request: {
-              headers: [{ name: '200a', style: HttpParamStyles.Simple }, { name: '200b', style: HttpParamStyles.Simple }],
+              headers: [
+                { name: '200a', style: HttpParamStyles.Simple },
+                { name: '200b', style: HttpParamStyles.Simple },
+              ],
             },
           },
         ],
@@ -189,7 +192,10 @@ describe('mergeOperations()', () => {
             path: '/a',
             responses: [{ code: '200' }],
             request: {
-              headers: [{ name: '200b', style: HttpParamStyles.Simple }, { name: '200c', style: HttpParamStyles.Simple }],
+              headers: [
+                { name: '200b', style: HttpParamStyles.Simple },
+                { name: '200c', style: HttpParamStyles.Simple },
+              ],
             },
           },
         ],
@@ -201,7 +207,11 @@ describe('mergeOperations()', () => {
         path: '/a',
         responses: [{ code: '200', headers: [], contents: [] }],
         request: {
-          headers: [{ name: '200a', style: HttpParamStyles.Simple }, { name: '200b', style: HttpParamStyles.Simple }, { name: '200c', style: HttpParamStyles.Simple }],
+          headers: [
+            { name: '200a', style: HttpParamStyles.Simple },
+            { name: '200b', style: HttpParamStyles.Simple },
+            { name: '200c', style: HttpParamStyles.Simple },
+          ],
         },
         servers: [],
       },

--- a/src/__tests__/merge.test.ts
+++ b/src/__tests__/merge.test.ts
@@ -127,6 +127,7 @@ describe('mergeOperations()', () => {
         path: '/a',
         responses: [{ code: '200', contents: [], headers: [] }, { code: '400' }, { code: '500' }],
         servers: [],
+        request: { headers: [] },
       },
       { id: '2', method: 'get', path: '/b', responses: [{ code: '200' }] },
       { id: '4', method: 'get', path: '/c', responses: [{ code: '200' }] },
@@ -142,7 +143,7 @@ describe('mergeOperations()', () => {
             method: 'get',
             path: '/a',
             responses: [{ code: '200' }],
-            servers: [{ url: 'http://exmaple.com' }],
+            servers: [{ url: 'http://example.com' }],
           },
         ],
         [
@@ -151,7 +152,7 @@ describe('mergeOperations()', () => {
             method: 'get',
             path: '/a',
             responses: [{ code: '200' }],
-            servers: [{ url: 'https://exmaple.com' }],
+            servers: [{ url: 'https://example.com' }],
           },
         ],
       ),
@@ -161,7 +162,48 @@ describe('mergeOperations()', () => {
         method: 'get',
         path: '/a',
         responses: [{ code: '200', headers: [], contents: [] }],
-        servers: [{ url: 'http://exmaple.com' }, { url: 'https://exmaple.com' }],
+        servers: [{ url: 'http://example.com' }, { url: 'https://example.com' }],
+        request: { headers: [] },
+      },
+    ]);
+  });
+
+  it('merges request correctly', () => {
+    expect(
+      mergeOperations(
+        [
+          {
+            id: '1',
+            method: 'get',
+            path: '/a',
+            responses: [{ code: '200' }],
+            request: {
+              headers: [{ name: '200a', style: HttpParamStyles.Simple }, { name: '200b', style: HttpParamStyles.Simple }],
+            },
+          },
+        ],
+        [
+          {
+            id: '2',
+            method: 'get',
+            path: '/a',
+            responses: [{ code: '200' }],
+            request: {
+              headers: [{ name: '200b', style: HttpParamStyles.Simple }, { name: '200c', style: HttpParamStyles.Simple }],
+            },
+          },
+        ],
+      ),
+    ).toEqual([
+      {
+        id: '1',
+        method: 'get',
+        path: '/a',
+        responses: [{ code: '200', headers: [], contents: [] }],
+        request: {
+          headers: [{ name: '200a', style: HttpParamStyles.Simple }, { name: '200b', style: HttpParamStyles.Simple }, { name: '200c', style: HttpParamStyles.Simple }],
+        },
+        servers: [],
       },
     ]);
   });

--- a/src/__tests__/merge.test.ts
+++ b/src/__tests__/merge.test.ts
@@ -1,4 +1,4 @@
-import { HttpParamStyles, IHttpOperation } from '@stoplight/types/dist';
+import { HttpParamStyles } from '@stoplight/types';
 import { mergeOperations, mergeResponses } from '../merge';
 
 describe('mergeResponses()', () => {

--- a/src/__tests__/merge.test.ts
+++ b/src/__tests__/merge.test.ts
@@ -1,0 +1,168 @@
+import { HttpParamStyles, IHttpOperation } from '@stoplight/types/dist';
+import { mergeOperations, mergeResponses } from '../merge';
+
+describe('mergeResponses()', () => {
+  it('merges headers correctly', () => {
+    expect(
+      mergeResponses(
+        [
+          {
+            code: '200',
+            headers: [
+              { name: '200h1', style: HttpParamStyles.Simple },
+              { name: '200h2', style: HttpParamStyles.Simple },
+            ],
+          },
+          {
+            code: '400',
+            headers: [
+              { name: '400h1', style: HttpParamStyles.Simple },
+              { name: '400h2', style: HttpParamStyles.Simple },
+            ],
+          },
+        ],
+        [
+          {
+            code: '200',
+            headers: [
+              { name: '200h2', style: HttpParamStyles.Simple },
+              { name: '200h3', style: HttpParamStyles.Simple },
+            ],
+          },
+          {
+            code: '500',
+            headers: [
+              { name: '500h1', style: HttpParamStyles.Simple },
+              { name: '500h2', style: HttpParamStyles.Simple },
+            ],
+          },
+        ],
+      ),
+    ).toEqual([
+      {
+        code: '200',
+        headers: [
+          { name: '200h1', style: HttpParamStyles.Simple },
+          { name: '200h2', style: HttpParamStyles.Simple },
+          { name: '200h3', style: HttpParamStyles.Simple },
+        ],
+        contents: [],
+      },
+      {
+        code: '400',
+        headers: [
+          { name: '400h1', style: HttpParamStyles.Simple },
+          { name: '400h2', style: HttpParamStyles.Simple },
+        ],
+      },
+      {
+        code: '500',
+        headers: [
+          { name: '500h1', style: HttpParamStyles.Simple },
+          { name: '500h2', style: HttpParamStyles.Simple },
+        ],
+      },
+    ]);
+  });
+
+  it('merges contents correctly', () => {
+    expect(
+      mergeResponses(
+        [
+          {
+            code: '200',
+            contents: [{ mediaType: '200-tion/a-son' }, { mediaType: '200-tion/b-son' }],
+          },
+          {
+            code: '400',
+            contents: [{ mediaType: '400-tion/a-son' }, { mediaType: '400-tion/b-son' }],
+          },
+        ],
+        [
+          {
+            code: '200',
+            contents: [{ mediaType: '200-tion/b-son' }, { mediaType: '200-tion/c-son' }],
+          },
+          {
+            code: '500',
+            contents: [{ mediaType: '500-tion/a-son' }, { mediaType: '500-tion/b-son' }],
+          },
+        ],
+      ),
+    ).toEqual([
+      {
+        code: '200',
+        contents: [{ mediaType: '200-tion/a-son' }, { mediaType: '200-tion/b-son' }, { mediaType: '200-tion/c-son' }],
+        headers: [],
+      },
+      {
+        code: '400',
+        contents: [{ mediaType: '400-tion/a-son' }, { mediaType: '400-tion/b-son' }],
+      },
+      {
+        code: '500',
+        contents: [{ mediaType: '500-tion/a-son' }, { mediaType: '500-tion/b-son' }],
+      },
+    ]);
+  });
+});
+
+describe('mergeOperations()', () => {
+  it('merges responses correctly', () => {
+    expect(
+      mergeOperations(
+        [
+          { id: '1', method: 'get', path: '/a', responses: [{ code: '200' }, { code: '400' }] },
+          { id: '2', method: 'get', path: '/b', responses: [{ code: '200' }] },
+        ],
+        [
+          { id: '3', method: 'get', path: '/a', responses: [{ code: '200' }, { code: '500' }] },
+          { id: '4', method: 'get', path: '/c', responses: [{ code: '200' }] },
+        ],
+      ),
+    ).toEqual([
+      {
+        id: '1',
+        method: 'get',
+        path: '/a',
+        responses: [{ code: '200', contents: [], headers: [] }, { code: '400' }, { code: '500' }],
+        servers: [],
+      },
+      { id: '2', method: 'get', path: '/b', responses: [{ code: '200' }] },
+      { id: '4', method: 'get', path: '/c', responses: [{ code: '200' }] },
+    ]);
+  });
+
+  it('merges servers correctly', () => {
+    expect(
+      mergeOperations(
+        [
+          {
+            id: '1',
+            method: 'get',
+            path: '/a',
+            responses: [{ code: '200' }],
+            servers: [{ url: 'http://exmaple.com' }],
+          },
+        ],
+        [
+          {
+            id: '2',
+            method: 'get',
+            path: '/a',
+            responses: [{ code: '200' }],
+            servers: [{ url: 'https://exmaple.com' }],
+          },
+        ],
+      ),
+    ).toEqual([
+      {
+        id: '1',
+        method: 'get',
+        path: '/a',
+        responses: [{ code: '200', headers: [], contents: [] }],
+        servers: [{ url: 'http://exmaple.com' }, { url: 'https://exmaple.com' }],
+      },
+    ]);
+  });
+});

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -28,6 +28,10 @@ export const mergeOperations = mergeLists<IHttpOperation>(
   (o1, o2) => o1.path === o2.path && o1.method === o2.method,
   (o1, o2) => ({
     ...o1,
+    request: {
+      ...o1.request,
+      headers: mergeHeaders(o1.request?.headers || [], o2.request?.headers || []),
+    },
     responses: mergeResponses(o1.responses, o2.responses) as IHttpOperation['responses'],
     servers: mergeServers(o1.servers || [], o2.servers || []),
   }),

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -1,13 +1,13 @@
-import { IHttpHeaderParam, IHttpOperation, IHttpOperationResponse, IMediaTypeContent } from '@stoplight/types';
+import { IHttpHeaderParam, IHttpOperation, IHttpOperationResponse, IMediaTypeContent, IServer } from '@stoplight/types';
 
 const mergeHeaders = mergeLists<IHttpHeaderParam>(
   (h1, h2) => h1.name === h2.name,
-  h1 => h1,
+  h1 => h1, // ignore header #2 if mediaTypes is equal
 );
 
 const mergeContents = mergeLists<IMediaTypeContent>(
   (c1, c2) => c1.mediaType === c2.mediaType,
-  c1 => c1,
+  c1 => c1, // ignore content #2 if mediaTypes is equal
 );
 
 export const mergeResponses = mergeLists<IHttpOperationResponse>(
@@ -19,11 +19,17 @@ export const mergeResponses = mergeLists<IHttpOperationResponse>(
   }),
 );
 
+const mergeServers = mergeLists<IServer>(
+  (s1, s2) => s1.url === s2.url,
+  s1 => s1, // ignore server #2 is url is equal
+);
+
 export const mergeOperations = mergeLists<IHttpOperation>(
   (o1, o2) => o1.path === o2.path && o1.method === o2.method,
   (o1, o2) => ({
     ...o1,
     responses: mergeResponses(o1.responses, o2.responses) as IHttpOperation['responses'],
+    servers: mergeServers(o1.servers || [], o2.servers || []),
   }),
 );
 

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -1,0 +1,43 @@
+import { IHttpHeaderParam, IHttpOperation, IHttpOperationResponse, IMediaTypeContent } from '@stoplight/types';
+
+const mergeHeaders = mergeLists<IHttpHeaderParam>(
+  (h1, h2) => h1.name === h2.name,
+  h1 => h1,
+);
+
+const mergeContents = mergeLists<IMediaTypeContent>(
+  (c1, c2) => c1.mediaType === c2.mediaType,
+  c1 => c1,
+);
+
+export const mergeResponses = mergeLists<IHttpOperationResponse>(
+  (r1, r2) => r1.code === r2.code,
+  (r1, r2) => ({
+    ...r1,
+    headers: mergeHeaders(r1.headers || [], r2.headers || []),
+    contents: mergeContents(r1.contents || [], r2.contents || []),
+  }),
+);
+
+export const mergeOperations = mergeLists<IHttpOperation>(
+  (o1, o2) => o1.path === o2.path && o1.method === o2.method,
+  (o1, o2) => ({
+    ...o1,
+    responses: mergeResponses(o1.responses, o2.responses) as IHttpOperation['responses'],
+  }),
+);
+
+function mergeLists<T>(compare: (o1: T, o2: T) => boolean, merge: (o1: T, o2: T) => T) {
+  return (items1: T[], items2: T[]) => {
+    return items2.reduce((items, item2) => {
+      const mergeTargetIdx = items.findIndex(item => compare(item, item2));
+      if (mergeTargetIdx > -1) {
+        items[mergeTargetIdx] = merge(items[mergeTargetIdx], item2);
+      } else {
+        items.push(item2);
+      }
+
+      return items;
+    }, items1.slice());
+  };
+}


### PR DESCRIPTION
Fixes #74.

Introduces the initial capability of merging together two `IHttpOperation`'s. 

The feature is required because:
- Postman stores as separate items making it possible to e.g. define few 200 responses
- Postman may store few items (operations) defining the same endpoint

There are few things missing to call it full-blown solution:
- security merging - might be slightly required by PC, we could consider adding it
- callbacks - not required for PC

Note: The only-client of this feature currently is Postman Collection transformations