### PR TITLE
Postman Collection: handles case when url.path is not defined

### DIFF
--- a/src/postman/transformers/request.ts
+++ b/src/postman/transformers/request.ts
@@ -15,7 +15,7 @@ export function transformRequest(request: Request): Required<IHttpOperationReque
   return {
     query: request.url.query.map(transformQueryParam),
     headers: request.headers.map(transformHeader),
-    path: transformPathParams(request.url.path),
+    path: transformPathParams(request.url.path || []),
     body: request.body ? transformBody(request.body, request.headers.get('content-type')?.toLowerCase()) : undefined,
   };
 }


### PR DESCRIPTION
Fixes case when `url.path` is not defined.

There is also a pull request to `DefinitelyTyped` which fixes the types: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42833