### PR TITLE
chore: improved typings for IHttpOperation merger

### DIFF
--- a/src/merge.ts
+++ b/src/merge.ts
@@ -1,16 +1,16 @@
 import { IHttpHeaderParam, IHttpOperation, IHttpOperationResponse, IMediaTypeContent, IServer } from '@stoplight/types';
 
-const mergeHeaders = mergeLists<IHttpHeaderParam>(
+const mergeHeaders = mergeLists<IHttpHeaderParam[]>(
   (h1, h2) => h1.name === h2.name,
   h1 => h1, // ignore header #2 if mediaTypes is equal
 );
 
-const mergeContents = mergeLists<IMediaTypeContent>(
+const mergeContents = mergeLists<IMediaTypeContent[]>(
   (c1, c2) => c1.mediaType === c2.mediaType,
   c1 => c1, // ignore content #2 if mediaTypes is equal
 );
 
-export const mergeResponses = mergeLists<IHttpOperationResponse>(
+export const mergeResponses = mergeLists<IHttpOperation['responses']>(
   (r1, r2) => r1.code === r2.code,
   (r1, r2) => ({
     ...r1,
@@ -19,12 +19,12 @@ export const mergeResponses = mergeLists<IHttpOperationResponse>(
   }),
 );
 
-const mergeServers = mergeLists<IServer>(
+const mergeServers = mergeLists<IServer[]>(
   (s1, s2) => s1.url === s2.url,
   s1 => s1, // ignore server #2 is url is equal
 );
 
-export const mergeOperations = mergeLists<IHttpOperation>(
+export const mergeOperations = mergeLists<IHttpOperation[]>(
   (o1, o2) => o1.path === o2.path && o1.method === o2.method,
   (o1, o2) => ({
     ...o1,
@@ -37,10 +37,10 @@ export const mergeOperations = mergeLists<IHttpOperation>(
   }),
 );
 
-function mergeLists<T>(compare: (o1: T, o2: T) => boolean, merge: (o1: T, o2: T) => T) {
-  return (items1: T[], items2: T[]) => {
+function mergeLists<T extends any[]>(compare: (o1: T[0], o2: T[0]) => boolean, merge: (o1: T[0], o2: T[0]) => T[0]) {
+  return (items1: T, items2: T) => {
     return items2.reduce((items, item2) => {
-      const mergeTargetIdx = items.findIndex(item => compare(item, item2));
+      const mergeTargetIdx = items.findIndex((item: T[0]) => compare(item, item2));
       if (mergeTargetIdx > -1) {
         items[mergeTargetIdx] = merge(items[mergeTargetIdx], item2);
       } else {

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -1,11 +1,11 @@
 import { IHttpHeaderParam, IHttpOperation, IHttpOperationResponse, IMediaTypeContent, IServer } from '@stoplight/types';
 
-const mergeHeaders = mergeLists<IHttpHeaderParam>(
+const mergeHeaders = mergeLists<IHttpHeaderParam[]>(
   (h1, h2) => h1.name.toLowerCase() === h2.name.toLowerCase(),
   h1 => h1, // ignore header #2 if mediaTypes is equal
 );
 
-const mergeContents = mergeLists<IMediaTypeContent>(
+const mergeContents = mergeLists<IMediaTypeContent[]>(
   (c1, c2) => c1.mediaType.toLowerCase() === c2.mediaType.toLowerCase(),
   c1 => c1, // ignore content #2 if mediaTypes is equal
 );
@@ -24,7 +24,7 @@ const mergeServers = mergeLists<IServer[]>(
   s1 => s1, // ignore server #2 is url is equal
 );
 
-export const mergeOperations = mergeLists<IHttpOperation>(
+export const mergeOperations = mergeLists<IHttpOperation[]>(
   (o1, o2) => o1.path === o2.path && o1.method.toLowerCase() === o2.method.toLowerCase(),
   (o1, o2) => ({
     ...o1,

--- a/src/postman/operation.ts
+++ b/src/postman/operation.ts
@@ -1,14 +1,4 @@
-import {
-  HttpParamStyles,
-  HttpSecurityScheme,
-  IHttpHeaderParam,
-  IHttpOperation,
-  IHttpOperationRequestBody,
-  IHttpParam,
-  IHttpPathParam,
-  IHttpQueryParam,
-  IMediaTypeContent,
-} from '@stoplight/types';
+import { HttpSecurityScheme, IHttpOperation } from '@stoplight/types';
 import { Collection, CollectionDefinition, Item, RequestAuth, Url } from 'postman-collection';
 import { mergeOperations, mergeResponses } from '../merge';
 import { transformRequest } from './transformers/request';
@@ -82,7 +72,7 @@ function transformItem(item: Item, securitySchemes: PostmanSecurityScheme[]): IH
     request,
     responses: item.responses.all().reduce<IHttpOperation['responses']>(
       (merged, response) => mergeResponses(merged, [transformResponse(response)]),
-      [] as any, // @todo do we want to load operations without responses?
+      [] as any, // this overrides the NonEmptyArray type on IHttpOperation.responses
     ),
     security,
     servers: server ? [server] : undefined,

--- a/src/postman/operation.ts
+++ b/src/postman/operation.ts
@@ -9,7 +9,6 @@ import {
   IHttpQueryParam,
   IMediaTypeContent,
 } from '@stoplight/types';
-import { IHttpOperationResponse } from '@stoplight/types/dist';
 import { Collection, CollectionDefinition, Item, RequestAuth, Url } from 'postman-collection';
 import { mergeOperations, mergeResponses } from '../merge';
 import { transformRequest } from './transformers/request';
@@ -81,12 +80,10 @@ function transformItem(item: Item, securitySchemes: PostmanSecurityScheme[]): IH
     path: getPath(item.request.url),
     summary: item.name,
     request,
-    responses: item.responses
-      .all()
-      .reduce<IHttpOperationResponse[]>(
-        (merged, response) => mergeResponses(merged, [transformResponse(response)]),
-        [],
-      ) as IHttpOperation['responses'],
+    responses: item.responses.all().reduce<IHttpOperation['responses']>(
+      (merged, response) => mergeResponses(merged, [transformResponse(response)]),
+      [] as any, // @todo do we want to load operations without responses?
+    ),
     security,
     servers: server ? [server] : undefined,
   };


### PR DESCRIPTION
This PR improves the typings of the merger. Now the merger function is typed with array type instead of the item type. That makes it possible to pass some more complex array types, like NonEmptyArray.

There is still an open case: https://github.com/stoplightio/http-spec/pull/82/files#diff-047f6c9db2a76331a04cf84790e05f5bR85. Should we prevent creating operations with empty responses on `http-spec` level? Currently, we allow such operations which result e.g. in prism being unable to mock such request. WDYT?