### PR TITLE
fix: handling letter cases when merging http ops

### DIFF
--- a/src/__tests__/merge.test.ts
+++ b/src/__tests__/merge.test.ts
@@ -65,6 +65,31 @@ describe('mergeResponses()', () => {
     ]);
   });
 
+  it('merges headers having differently cased letters in name', () => {
+    expect(
+      mergeResponses(
+        [
+          {
+            code: '200',
+            headers: [{ name: 'Oo', style: HttpParamStyles.Simple }],
+          },
+        ],
+        [
+          {
+            code: '200',
+            headers: [{ name: 'oO', style: HttpParamStyles.Simple }],
+          },
+        ],
+      ),
+    ).toEqual([
+      {
+        code: '200',
+        headers: [{ name: 'Oo', style: HttpParamStyles.Simple }],
+        contents: [],
+      },
+    ]);
+  });
+
   it('merges contents correctly', () => {
     expect(
       mergeResponses(
@@ -102,6 +127,31 @@ describe('mergeResponses()', () => {
       {
         code: '500',
         contents: [{ mediaType: '500-tion/a-son' }, { mediaType: '500-tion/b-son' }],
+      },
+    ]);
+  });
+
+  it('merges contents having differently cased letters in name', () => {
+    expect(
+      mergeResponses(
+        [
+          {
+            code: '200',
+            contents: [{ mediaType: 'Aa/Oo' }],
+          },
+        ],
+        [
+          {
+            code: '200',
+            contents: [{ mediaType: 'aA/oO' }],
+          },
+        ],
+      ),
+    ).toEqual([
+      {
+        code: '200',
+        contents: [{ mediaType: 'Aa/Oo' }],
+        headers: [],
       },
     ]);
   });
@@ -163,6 +213,40 @@ describe('mergeOperations()', () => {
         path: '/a',
         responses: [{ code: '200', headers: [], contents: [] }],
         servers: [{ url: 'http://example.com' }, { url: 'https://example.com' }],
+        request: { headers: [] },
+      },
+    ]);
+  });
+
+  it('merges servers where urls are expressed with different letter case', () => {
+    expect(
+      mergeOperations(
+        [
+          {
+            id: '1',
+            method: 'get',
+            path: '/a',
+            responses: [{ code: '200' }],
+            servers: [{ url: 'http://example.com' }],
+          },
+        ],
+        [
+          {
+            id: '2',
+            method: 'get',
+            path: '/a',
+            responses: [{ code: '200' }],
+            servers: [{ url: 'http://example.COM' }],
+          },
+        ],
+      ),
+    ).toEqual([
+      {
+        id: '1',
+        method: 'get',
+        path: '/a',
+        responses: [{ code: '200', headers: [], contents: [] }],
+        servers: [{ url: 'http://example.com' }],
         request: { headers: [] },
       },
     ]);

--- a/src/__tests__/merge.test.ts
+++ b/src/__tests__/merge.test.ts
@@ -218,40 +218,6 @@ describe('mergeOperations()', () => {
     ]);
   });
 
-  it('merges servers where urls are expressed with different letter case', () => {
-    expect(
-      mergeOperations(
-        [
-          {
-            id: '1',
-            method: 'get',
-            path: '/a',
-            responses: [{ code: '200' }],
-            servers: [{ url: 'http://example.com' }],
-          },
-        ],
-        [
-          {
-            id: '2',
-            method: 'get',
-            path: '/a',
-            responses: [{ code: '200' }],
-            servers: [{ url: 'http://example.COM' }],
-          },
-        ],
-      ),
-    ).toEqual([
-      {
-        id: '1',
-        method: 'get',
-        path: '/a',
-        responses: [{ code: '200', headers: [], contents: [] }],
-        servers: [{ url: 'http://example.com' }],
-        request: { headers: [] },
-      },
-    ]);
-  });
-
   it('merges request correctly', () => {
     expect(
       mergeOperations(

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -20,7 +20,7 @@ export const mergeResponses = mergeLists<IHttpOperationResponse>(
 );
 
 const mergeServers = mergeLists<IServer>(
-  (s1, s2) => s1.url.toLowerCase() === s2.url.toLowerCase(),
+  (s1, s2) => s1.url === s2.url,
   s1 => s1, // ignore server #2 is url is equal
 );
 

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -1,12 +1,12 @@
 import { IHttpHeaderParam, IHttpOperation, IHttpOperationResponse, IMediaTypeContent, IServer } from '@stoplight/types';
 
 const mergeHeaders = mergeLists<IHttpHeaderParam>(
-  (h1, h2) => h1.name === h2.name,
+  (h1, h2) => h1.name.toLowerCase() === h2.name.toLowerCase(),
   h1 => h1, // ignore header #2 if mediaTypes is equal
 );
 
 const mergeContents = mergeLists<IMediaTypeContent>(
-  (c1, c2) => c1.mediaType === c2.mediaType,
+  (c1, c2) => c1.mediaType.toLowerCase() === c2.mediaType.toLowerCase(),
   c1 => c1, // ignore content #2 if mediaTypes is equal
 );
 
@@ -20,12 +20,12 @@ export const mergeResponses = mergeLists<IHttpOperationResponse>(
 );
 
 const mergeServers = mergeLists<IServer>(
-  (s1, s2) => s1.url === s2.url,
+  (s1, s2) => s1.url.toLowerCase() === s2.url.toLowerCase(),
   s1 => s1, // ignore server #2 is url is equal
 );
 
 export const mergeOperations = mergeLists<IHttpOperation>(
-  (o1, o2) => o1.path === o2.path && o1.method === o2.method,
+  (o1, o2) => o1.path === o2.path && o1.method.toLowerCase() === o2.method.toLowerCase(),
   (o1, o2) => ({
     ...o1,
     request: {


### PR DESCRIPTION
Case insensitive comparison of header/mediaType/server.url when merging.