### PR TITLE
fix: commonjs

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,11 @@
 {
   "extends": "@stoplight/scripts/tsconfig.json",
   // target all ts files
-  "include": ["."],
+  "include": [
+    "."
+  ],
   "compilerOptions": {
+    "module": "commonjs",
     "noUnusedLocals": false
   }
 }


### PR DESCRIPTION
Http-Spec has been upgraded to sl-scripts 8 which does not produce commonjs exports. This PR restores the output to what it was before