### PR TITLE
fix: local references in params and responses

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,3 @@
 module.exports = {
   extends: ['@stoplight'],
-  rules: {
-    'no-param-reassign': 'off',
-  },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,6 @@
 module.exports = {
-  extends: ["@stoplight"],
+  extends: ['@stoplight'],
+  rules: {
+    'no-param-reassign': 'off',
+  },
 };

--- a/src/oas/__tests__/__snapshots__/operation.test.ts.snap
+++ b/src/oas/__tests__/__snapshots__/operation.test.ts.snap
@@ -86,7 +86,33 @@ Array [
     "id": "?http-operation-id?",
     "method": "get",
     "path": "/pets",
-    "request": Object {},
+    "request": Object {
+      "headers": Array [
+        Object {
+          "name": "Rate-Limit",
+          "schema": Object {
+            "type": "string",
+          },
+          "style": "simple",
+        },
+      ],
+      "query": Array [
+        Object {
+          "name": "skip",
+          "schema": Object {
+            "type": "string",
+          },
+          "style": "form",
+        },
+        Object {
+          "name": "limit",
+          "schema": Object {
+            "type": "string",
+          },
+          "style": "form",
+        },
+      ],
+    },
     "responses": Array [
       Object {
         "code": "200",
@@ -111,7 +137,33 @@ Array [
     "id": "?http-operation-id?",
     "method": "options",
     "path": "/pets",
-    "request": Object {},
+    "request": Object {
+      "headers": Array [
+        Object {
+          "name": "Rate-Limit",
+          "schema": Object {
+            "type": "string",
+          },
+          "style": "simple",
+        },
+      ],
+      "query": Array [
+        Object {
+          "name": "skip",
+          "schema": Object {
+            "type": "string",
+          },
+          "style": "form",
+        },
+        Object {
+          "name": "limit",
+          "schema": Object {
+            "type": "string",
+          },
+          "style": "form",
+        },
+      ],
+    },
     "responses": Array [
       Object {
         "code": "200",
@@ -209,6 +261,16 @@ Array [
         "description": "Pet object that needs to be added to the store",
         "required": true,
       },
+      "path": Array [
+        Object {
+          "name": "petId",
+          "required": true,
+          "schema": Object {
+            "type": "string",
+          },
+          "style": "simple",
+        },
+      ],
     },
     "responses": Array [
       Object {
@@ -234,15 +296,19 @@ Array [
           Object {
             "examples": Array [],
             "mediaType": "application/xml",
-            "schema": undefined,
+            "schema": Object {
+              "$ref": "#/definitions/Error",
+            },
           },
           Object {
             "examples": Array [],
             "mediaType": "application/json",
-            "schema": undefined,
+            "schema": Object {
+              "$ref": "#/definitions/Error",
+            },
           },
         ],
-        "description": undefined,
+        "description": "Our shared 404 response.",
         "headers": Array [],
       },
       Object {
@@ -373,7 +439,22 @@ Array [
       "cookie": Array [],
       "headers": Array [],
       "path": Array [],
-      "query": Array [],
+      "query": Array [
+        Object {
+          "examples": Array [],
+          "name": "skip",
+          "schema": Object {
+            "type": "string",
+          },
+        },
+        Object {
+          "examples": Array [],
+          "name": "limit",
+          "schema": Object {
+            "type": "string",
+          },
+        },
+      ],
     },
     "responses": Array [
       Object {
@@ -423,7 +504,16 @@ Array [
       },
       "cookie": Array [],
       "headers": Array [],
-      "path": Array [],
+      "path": Array [
+        Object {
+          "examples": Array [],
+          "name": "petId",
+          "required": true,
+          "schema": Object {
+            "type": "string",
+          },
+        },
+      ],
       "query": Array [],
     },
     "responses": Array [
@@ -431,6 +521,22 @@ Array [
         "code": "400",
         "contents": Array [],
         "description": "Invalid ID supplied",
+        "headers": Array [],
+      },
+      Object {
+        "code": "404",
+        "contents": Array [
+          Object {
+            "encodings": Array [],
+            "examples": Array [],
+            "mediaType": "*/*",
+            "schema": Object {
+              "$ref": "#/components/schemas/Error",
+              "$schema": "http://json-schema.org/draft-04/schema#",
+            },
+          },
+        ],
+        "description": "Our shared 404 response.",
         "headers": Array [],
       },
       Object {

--- a/src/oas/__tests__/__snapshots__/operation.test.ts.snap
+++ b/src/oas/__tests__/__snapshots__/operation.test.ts.snap
@@ -1,0 +1,480 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`oas operation openapi v2 1`] = `
+Array [
+  Object {
+    "description": "",
+    "id": "?http-operation-id?",
+    "iid": "addPet",
+    "method": "post",
+    "path": "/pets",
+    "request": Object {
+      "body": Object {
+        "contents": Array [
+          Object {
+            "examples": Array [],
+            "mediaType": "application/json",
+            "schema": Object {
+              "$ref": "#/definitions/Pet",
+            },
+          },
+          Object {
+            "examples": Array [],
+            "mediaType": "application/xml",
+            "schema": Object {
+              "$ref": "#/definitions/Pet",
+            },
+          },
+        ],
+        "description": "Pet object that needs to be added to the store",
+        "required": true,
+      },
+    },
+    "responses": Array [
+      Object {
+        "code": "405",
+        "contents": Array [
+          Object {
+            "examples": Array [],
+            "mediaType": "application/xml",
+            "schema": undefined,
+          },
+          Object {
+            "examples": Array [],
+            "mediaType": "application/json",
+            "schema": undefined,
+          },
+        ],
+        "description": "Invalid input",
+        "headers": Array [],
+      },
+    ],
+    "security": Array [
+      Array [
+        Object {
+          "description": undefined,
+          "flows": Object {
+            "implicit": Object {
+              "authorizationUrl": "https://petstore.swagger.io/oauth/dialog",
+              "scopes": Object {
+                "read:pets": "read your pets",
+                "write:pets": "modify pets in your account",
+              },
+            },
+          },
+          "key": "petstore_auth",
+          "type": "oauth2",
+        },
+      ],
+    ],
+    "servers": Array [
+      Object {
+        "url": "https://petstore.swagger.io/v2",
+      },
+      Object {
+        "url": "http://petstore.swagger.io/v2",
+      },
+    ],
+    "summary": "Add a new pet to the store",
+    "tags": Array [
+      Object {
+        "name": "pet",
+      },
+    ],
+  },
+  Object {
+    "id": "?http-operation-id?",
+    "method": "get",
+    "path": "/pets",
+    "request": Object {},
+    "responses": Array [
+      Object {
+        "code": "200",
+        "contents": Array [],
+        "description": "",
+        "headers": Array [],
+      },
+    ],
+    "security": Array [],
+    "servers": Array [
+      Object {
+        "url": "https://petstore.swagger.io/v2",
+      },
+      Object {
+        "url": "http://petstore.swagger.io/v2",
+      },
+    ],
+    "summary": "List pets",
+    "tags": Array [],
+  },
+  Object {
+    "id": "?http-operation-id?",
+    "method": "options",
+    "path": "/pets",
+    "request": Object {},
+    "responses": Array [
+      Object {
+        "code": "200",
+        "contents": Array [],
+        "description": "",
+        "headers": Array [
+          Object {
+            "description": "Allowed clients",
+            "name": "Allow",
+            "schema": Object {
+              "type": "string",
+            },
+            "style": "simple",
+          },
+          Object {
+            "description": "Remaining requests",
+            "name": "X-Rate-Limit",
+            "schema": Object {
+              "format": "int64",
+              "type": "number",
+            },
+            "style": "simple",
+          },
+        ],
+      },
+    ],
+    "security": Array [],
+    "servers": Array [
+      Object {
+        "url": "https://petstore.swagger.io/v2",
+      },
+      Object {
+        "url": "http://petstore.swagger.io/v2",
+      },
+    ],
+    "summary": "List pets",
+    "tags": Array [],
+  },
+  Object {
+    "description": "",
+    "id": "?http-operation-id?",
+    "method": "delete",
+    "path": "/pets",
+    "request": Object {},
+    "responses": Array [
+      Object {
+        "code": "400",
+        "contents": Array [],
+        "description": "Invalid ID supplied",
+        "headers": Array [],
+      },
+      Object {
+        "code": "404",
+        "contents": Array [],
+        "description": "Pet not found",
+        "headers": Array [],
+      },
+    ],
+    "security": Array [],
+    "servers": Array [
+      Object {
+        "url": "https://petstore.swagger.io/v2",
+      },
+      Object {
+        "url": "http://petstore.swagger.io/v2",
+      },
+    ],
+    "summary": "Deletes a pet",
+    "tags": Array [],
+  },
+  Object {
+    "description": "",
+    "id": "?http-operation-id?",
+    "iid": "updatePet",
+    "method": "put",
+    "path": "/pet/{petId}",
+    "request": Object {
+      "body": Object {
+        "contents": Array [
+          Object {
+            "examples": Array [],
+            "mediaType": "application/json",
+            "schema": Object {
+              "$ref": "#/definitions/Pet",
+            },
+          },
+          Object {
+            "examples": Array [],
+            "mediaType": "application/xml",
+            "schema": Object {
+              "$ref": "#/definitions/Pet",
+            },
+          },
+        ],
+        "description": "Pet object that needs to be added to the store",
+        "required": true,
+      },
+    },
+    "responses": Array [
+      Object {
+        "code": "400",
+        "contents": Array [
+          Object {
+            "examples": Array [],
+            "mediaType": "application/xml",
+            "schema": undefined,
+          },
+          Object {
+            "examples": Array [],
+            "mediaType": "application/json",
+            "schema": undefined,
+          },
+        ],
+        "description": "Invalid ID supplied",
+        "headers": Array [],
+      },
+      Object {
+        "code": "404",
+        "contents": Array [
+          Object {
+            "examples": Array [],
+            "mediaType": "application/xml",
+            "schema": undefined,
+          },
+          Object {
+            "examples": Array [],
+            "mediaType": "application/json",
+            "schema": undefined,
+          },
+        ],
+        "description": undefined,
+        "headers": Array [],
+      },
+      Object {
+        "code": "405",
+        "contents": Array [
+          Object {
+            "examples": Array [],
+            "mediaType": "application/xml",
+            "schema": undefined,
+          },
+          Object {
+            "examples": Array [],
+            "mediaType": "application/json",
+            "schema": undefined,
+          },
+        ],
+        "description": "Validation exception",
+        "headers": Array [],
+      },
+    ],
+    "security": Array [
+      Array [
+        Object {
+          "description": undefined,
+          "flows": Object {
+            "implicit": Object {
+              "authorizationUrl": "https://petstore.swagger.io/oauth/dialog",
+              "scopes": Object {
+                "read:pets": "read your pets",
+                "write:pets": "modify pets in your account",
+              },
+            },
+          },
+          "key": "petstore_auth",
+          "type": "oauth2",
+        },
+      ],
+    ],
+    "servers": Array [
+      Object {
+        "url": "https://petstore.swagger.io/v2",
+      },
+      Object {
+        "url": "http://petstore.swagger.io/v2",
+      },
+    ],
+    "summary": "Update an existing pet",
+    "tags": Array [
+      Object {
+        "name": "pet",
+      },
+    ],
+  },
+]
+`;
+
+exports[`oas operation openapi v3 1`] = `
+Array [
+  Object {
+    "description": "",
+    "id": "?http-operation-id?",
+    "iid": "addPet",
+    "method": "post",
+    "path": "/pets",
+    "request": Object {
+      "body": Object {
+        "contents": Array [],
+        "description": undefined,
+        "required": undefined,
+      },
+      "cookie": Array [],
+      "headers": Array [],
+      "path": Array [],
+      "query": Array [],
+    },
+    "responses": Array [
+      Object {
+        "code": "405",
+        "contents": Array [],
+        "description": "Invalid input",
+        "headers": Array [],
+      },
+    ],
+    "security": Array [
+      Array [
+        Object {
+          "flows": Object {
+            "implicit": Object {
+              "authorizationUrl": "https://petstore.swagger.io/oauth/dialog",
+              "scopes": Object {
+                "read:pets": "read your pets",
+                "write:pets": "modify pets in your account",
+              },
+            },
+          },
+          "key": "petstore_auth",
+          "type": "oauth2",
+        },
+      ],
+    ],
+    "servers": Array [
+      Object {
+        "description": undefined,
+        "url": "https://petstore.swagger.io/v2",
+        "variables": undefined,
+      },
+      Object {
+        "description": undefined,
+        "url": "http://petstore.swagger.io/v2",
+        "variables": undefined,
+      },
+    ],
+    "summary": "Add a new pet to the store",
+    "tags": Array [
+      Object {
+        "name": "pet",
+      },
+    ],
+  },
+  Object {
+    "id": "?http-operation-id?",
+    "method": "get",
+    "path": "/pets",
+    "request": Object {
+      "body": Object {
+        "contents": Array [],
+      },
+      "cookie": Array [],
+      "headers": Array [],
+      "path": Array [],
+      "query": Array [],
+    },
+    "responses": Array [
+      Object {
+        "code": "200",
+        "contents": Array [
+          Object {
+            "encodings": Array [],
+            "examples": Array [],
+            "mediaType": "*/*",
+            "schema": Object {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "type": "object",
+            },
+          },
+        ],
+        "description": "OK",
+        "headers": Array [],
+      },
+    ],
+    "security": Array [],
+    "servers": Array [
+      Object {
+        "description": undefined,
+        "url": "https://petstore.swagger.io/v2",
+        "variables": undefined,
+      },
+      Object {
+        "description": undefined,
+        "url": "http://petstore.swagger.io/v2",
+        "variables": undefined,
+      },
+    ],
+    "summary": "List pets",
+    "tags": Array [],
+  },
+  Object {
+    "description": "",
+    "id": "?http-operation-id?",
+    "iid": "updatePet",
+    "method": "put",
+    "path": "/pet/{petId}",
+    "request": Object {
+      "body": Object {
+        "contents": Array [],
+        "description": undefined,
+        "required": undefined,
+      },
+      "cookie": Array [],
+      "headers": Array [],
+      "path": Array [],
+      "query": Array [],
+    },
+    "responses": Array [
+      Object {
+        "code": "400",
+        "contents": Array [],
+        "description": "Invalid ID supplied",
+        "headers": Array [],
+      },
+      Object {
+        "code": "405",
+        "contents": Array [],
+        "description": "Validation exception",
+        "headers": Array [],
+      },
+    ],
+    "security": Array [
+      Array [
+        Object {
+          "flows": Object {
+            "implicit": Object {
+              "authorizationUrl": "https://petstore.swagger.io/oauth/dialog",
+              "scopes": Object {
+                "read:pets": "read your pets",
+                "write:pets": "modify pets in your account",
+              },
+            },
+          },
+          "key": "petstore_auth",
+          "type": "oauth2",
+        },
+      ],
+    ],
+    "servers": Array [
+      Object {
+        "description": undefined,
+        "url": "https://petstore.swagger.io/v2",
+        "variables": undefined,
+      },
+      Object {
+        "description": undefined,
+        "url": "http://petstore.swagger.io/v2",
+        "variables": undefined,
+      },
+    ],
+    "summary": "Update an existing pet",
+    "tags": Array [
+      Object {
+        "name": "pet",
+      },
+    ],
+  },
+]
+`;

--- a/src/oas/__tests__/accessors.test.ts
+++ b/src/oas/__tests__/accessors.test.ts
@@ -2,12 +2,13 @@ import { getOasTags, getValidOasParameters } from '../accessors';
 
 describe('getOasParameters', () => {
   it('should return empty array', () => {
-    expect(getValidOasParameters(undefined, undefined)).toEqual([]);
+    expect(getValidOasParameters({}, undefined, undefined)).toEqual([]);
   });
 
   it('should fallback to operation parameters', () => {
     expect(
       getValidOasParameters(
+        {},
         [
           { name: 'n1', in: 'i1' },
           { name: 'n2', in: 'i2' },
@@ -28,7 +29,7 @@ describe('getOasParameters', () => {
 
   it('should fallback to path parameters', () => {
     expect(
-      getValidOasParameters(undefined, [
+      getValidOasParameters({}, undefined, [
         { name: 'n1', in: 'i1' },
         { name: 'n2', in: 'i2' },
       ]),
@@ -47,6 +48,7 @@ describe('getOasParameters', () => {
   it('should prefer operation parameters', () => {
     expect(
       getValidOasParameters(
+        {},
         [
           { name: 'n1', in: 'n1', type: 'array' },
           { name: 'no2', in: 'io2' },

--- a/src/oas/__tests__/operation.test.ts
+++ b/src/oas/__tests__/operation.test.ts
@@ -9,10 +9,16 @@ const oas3KitchenSinkJson: OpenAPIObject = require('./fixtures//oas3-kitchen-sin
 
 describe('oas operation', () => {
   it('openapi v2', () => {
-    expect(transformOas2Operations(oas2KitchenSinkJson)).toHaveLength(5);
+    const result = transformOas2Operations(oas2KitchenSinkJson);
+
+    expect(result).toHaveLength(5);
+    expect(result).toMatchSnapshot();
   });
 
   it('openapi v3', () => {
-    expect(transformOas3Operations(oas3KitchenSinkJson)).toHaveLength(3);
+    const result = transformOas3Operations(oas3KitchenSinkJson);
+
+    expect(result).toHaveLength(3);
+    expect(result).toMatchSnapshot();
   });
 });

--- a/src/oas/accessors.ts
+++ b/src/oas/accessors.ts
@@ -7,10 +7,10 @@ export function getValidOasParameters<ParamType extends { name: string; in: stri
   operationParameters: ParamType[] | undefined,
   pathParameters: ParamType[] | undefined,
 ) {
-  const op = map(operationParameters, x => maybeResolveLocalRef(document, x) as ParamType);
-  const pp = map(pathParameters, x => maybeResolveLocalRef(document, x) as ParamType);
+  const resolvedOperationParams = map(operationParameters, x => maybeResolveLocalRef(document, x) as ParamType);
+  const resolvedPathParams = map(pathParameters, x => maybeResolveLocalRef(document, x) as ParamType);
 
-  return unionBy(op, pp, (parameter?: ParamType) => {
+  return unionBy(resolvedOperationParams, resolvedPathParams, (parameter?: ParamType) => {
     return isObject(parameter) ? `${parameter.name}-${parameter.in}` : 'invalid';
   }).filter(isObject);
 }

--- a/src/oas/accessors.ts
+++ b/src/oas/accessors.ts
@@ -1,12 +1,18 @@
-import { isObject, unionBy } from 'lodash';
+import { isObject, map, unionBy } from 'lodash';
+
+import { maybeResolveLocalRef } from '../utils';
 
 export function getValidOasParameters<ParamType extends { name: string; in: string }>(
+  document: unknown,
   operationParameters: ParamType[] | undefined,
   pathParameters: ParamType[] | undefined,
 ) {
-  return unionBy(operationParameters, pathParameters, (parameter?: ParamType) =>
-    isObject(parameter) ? `${parameter.name}-${parameter.in}` : 'invalid',
-  ).filter(isObject);
+  const op = map(operationParameters, x => maybeResolveLocalRef(document, x) as ParamType);
+  const pp = map(pathParameters, x => maybeResolveLocalRef(document, x) as ParamType);
+
+  return unionBy(op, pp, (parameter?: ParamType) => {
+    return isObject(parameter) ? `${parameter.name}-${parameter.in}` : 'invalid';
+  }).filter(isObject);
 }
 
 export function getOasTags(tags: unknown): string[] {

--- a/src/oas2/guards.ts
+++ b/src/oas2/guards.ts
@@ -1,6 +1,6 @@
 import { Dictionary } from '@stoplight/types';
 import { isObject } from 'lodash';
-import { Security, Tag } from 'swagger-schema-official';
+import type { Response, Security, Tag } from 'swagger-schema-official';
 
 export function isSecurityScheme(maybeSecurityScheme: unknown): maybeSecurityScheme is Security {
   return isObject(maybeSecurityScheme) && typeof (maybeSecurityScheme as Dictionary<unknown>).type === 'string';
@@ -13,3 +13,10 @@ export const isTagObject = (maybeTagObject: unknown): maybeTagObject is Tag => {
 
   return false;
 };
+
+export const isResponseObject = (maybeResponseObject: unknown): maybeResponseObject is Response =>
+  isObject(maybeResponseObject) &&
+  ('description' in maybeResponseObject ||
+    'schema' in maybeResponseObject ||
+    'headers' in maybeResponseObject ||
+    'examples' in maybeResponseObject);

--- a/src/oas2/transformers/__tests__/responses.test.ts
+++ b/src/oas2/transformers/__tests__/responses.test.ts
@@ -16,6 +16,7 @@ describe('responses', () => {
 
   it('should translate to multiple responses', () => {
     const responses = translateToResponses(
+      {},
       {
         r1: {
           description: 'd1',
@@ -43,6 +44,7 @@ describe('responses', () => {
   it('should translate to response w/o headers', () => {
     expect(
       translateToResponses(
+        {},
         {
           r1: {
             description: 'd1',
@@ -60,6 +62,7 @@ describe('responses', () => {
   it('should translate to response w/o examples', () => {
     expect(
       translateToResponses(
+        {},
         {
           r1: {
             description: 'd1',
@@ -74,6 +77,7 @@ describe('responses', () => {
   describe('should keep foreign examples', () => {
     it('aggregating them to the first example', () => {
       const responses = translateToResponses(
+        {},
         {
           r1: {
             description: 'd1',
@@ -100,6 +104,7 @@ describe('responses', () => {
     describe('given a response with a schema with an example', () => {
       it('should translate to response with examples', () => {
         const responses = translateToResponses(
+          {},
           {
             r1: {
               description: 'd1',
@@ -120,6 +125,7 @@ describe('responses', () => {
     describe('given multiple schema example properties', () => {
       it('should translate all examples', () => {
         const responses = translateToResponses(
+          {},
           {
             r1: {
               description: 'd1',
@@ -148,6 +154,7 @@ describe('responses', () => {
     describe('given response with examples in root and schema objects', () => {
       it('root examples should take precedence over schema examples', () => {
         const responses = translateToResponses(
+          {},
           {
             r1: {
               description: 'd1',

--- a/src/oas2/transformers/responses.ts
+++ b/src/oas2/transformers/responses.ts
@@ -1,51 +1,72 @@
-import { IHttpOperationResponse } from '@stoplight/types';
+import { DeepPartial, Dictionary, IHttpOperationResponse, Optional } from '@stoplight/types';
 import { JSONSchema4 } from 'json-schema';
-import { chain, map, partial } from 'lodash';
-import { Response } from 'swagger-schema-official';
+import { chain, compact, map, partial } from 'lodash';
+import type { Response, Spec } from 'swagger-schema-official';
 
+import { isDictionary, maybeResolveLocalRef } from '../../utils';
+import { isResponseObject } from '../guards';
 import { getExamplesFromSchema } from './getExamplesFromSchema';
 import { translateToHeaderParams } from './params';
 
-function translateToResponse(produces: string[], response: Response, statusCode: string): IHttpOperationResponse {
-  const headers = translateToHeaderParams(response.headers || {});
-  const objectifiedExamples = chain(
-    response.examples || (response.schema ? getExamplesFromSchema(response.schema) : void 0),
-  )
-    .mapValues((value, key) => ({ key, value }))
-    .values()
-    .value();
+function responseTransformer(document: DeepPartial<Spec>) {
+  return function translateToResponse(
+    produces: string[],
+    response: unknown,
+    statusCode: string,
+  ): Optional<IHttpOperationResponse> {
+    response = maybeResolveLocalRef(document, response);
+    if (!isResponseObject(response)) return;
 
-  const contents = produces.map(produceElement => ({
-    mediaType: produceElement,
-    schema: response.schema as JSONSchema4,
-    examples: objectifiedExamples.filter(example => example.key === produceElement),
-  }));
+    const headers = translateToHeaderParams(response.headers || {});
+    const objectifiedExamples = chain(
+      response.examples || (response.schema ? getExamplesFromSchema(response.schema) : void 0),
+    )
+      .mapValues((value, key) => ({ key, value }))
+      .values()
+      .value();
 
-  const translatedResponses = {
-    code: statusCode,
-    description: response.description,
-    headers,
-    contents,
+    const contents = produces.map(produceElement => ({
+      mediaType: produceElement,
+      schema: (response as Response).schema as JSONSchema4,
+      examples: objectifiedExamples.filter(example => example.key === produceElement),
+    }));
+
+    const translatedResponses = {
+      code: statusCode,
+      description: response.description,
+      headers,
+      contents,
+    };
+
+    const foreignExamples = objectifiedExamples.filter(example => !produces.includes(example.key));
+    if (foreignExamples.length > 0) {
+      if (translatedResponses.contents.length === 0)
+        translatedResponses.contents[0] = {
+          mediaType: '',
+          schema: {},
+          examples: [],
+        };
+
+      translatedResponses.contents[0].examples!.push(...foreignExamples);
+    }
+
+    return translatedResponses;
   };
-
-  const foreignExamples = objectifiedExamples.filter(example => !produces.includes(example.key));
-  if (foreignExamples.length > 0) {
-    if (translatedResponses.contents.length === 0)
-      translatedResponses.contents[0] = {
-        mediaType: '',
-        schema: {},
-        examples: [],
-      };
-
-    translatedResponses.contents[0].examples!.push(...foreignExamples);
-  }
-
-  return translatedResponses;
 }
 
 export function translateToResponses(
-  responses: { [name: string]: Response },
+  document: DeepPartial<Spec>,
+  responses: unknown,
   produces: string[],
 ): IHttpOperationResponse[] {
-  return map(responses, partial(translateToResponse, produces));
+  if (!isDictionary(responses)) {
+    return [];
+  }
+
+  return compact<IHttpOperationResponse>(
+    map<Dictionary<unknown>, Optional<IHttpOperationResponse>>(
+      responses,
+      partial(responseTransformer(document), produces),
+    ),
+  );
 }

--- a/src/oas2/transformers/responses.ts
+++ b/src/oas2/transformers/responses.ts
@@ -1,4 +1,4 @@
-import { DeepPartial, Dictionary, IHttpOperationResponse, Optional } from '@stoplight/types';
+import type { DeepPartial, Dictionary, IHttpOperationResponse, Optional } from '@stoplight/types';
 import { JSONSchema4 } from 'json-schema';
 import { chain, compact, map, partial } from 'lodash';
 import type { Response, Spec } from 'swagger-schema-official';

--- a/src/oas3/accessors.ts
+++ b/src/oas3/accessors.ts
@@ -1,4 +1,4 @@
-import { DeepPartial, Dictionary, HttpSecurityScheme } from '@stoplight/types';
+import type { DeepPartial, Dictionary, HttpSecurityScheme } from '@stoplight/types';
 import { isObject } from 'lodash';
 import { OpenAPIObject } from 'openapi3-ts';
 

--- a/src/oas3/transformers/__tests__/responses.test.ts
+++ b/src/oas3/transformers/__tests__/responses.test.ts
@@ -2,61 +2,67 @@ import { translateToResponses } from '../responses';
 
 describe('translateToOas3Responses', () => {
   it('given empty dictionary should return empty array', () => {
-    expect(translateToResponses({})).toEqual([]);
+    expect(translateToResponses({}, {})).toEqual([]);
   });
 
   it('given a response in dictionary should translate', () => {
     expect(
-      translateToResponses({
-        default: {
-          content: {
-            'fake-content-type': {},
-          },
-          description: 'descr',
-          headers: {
-            'fake-header-name-1': {
-              description: 'calls per hour allowed by the user',
-              schema: {
-                type: 'integer',
-                format: 'int32',
-              },
-              example: 1000,
+      translateToResponses(
+        {},
+        {
+          default: {
+            content: {
+              'fake-content-type': {},
             },
-            'fake-header-name-2': {
-              description: 'calls per hour allowed by the user',
-              schema: {
-                type: 'integer',
-                format: 'int32',
+            description: 'descr',
+            headers: {
+              'fake-header-name-1': {
+                description: 'calls per hour allowed by the user',
+                schema: {
+                  type: 'integer',
+                  format: 'int32',
+                },
+                example: 1000,
               },
-              required: true,
-              example: 1000,
+              'fake-header-name-2': {
+                description: 'calls per hour allowed by the user',
+                schema: {
+                  type: 'integer',
+                  format: 'int32',
+                },
+                required: true,
+                example: 1000,
+              },
+            },
+          },
+          200: {
+            content: {
+              'fake-content-type-200': {
+                example: 'dumb',
+              },
+            },
+            description: 'descr 200',
+            headers: {
+              'fake-header-name-200': {},
             },
           },
         },
-        200: {
-          content: {
-            'fake-content-type-200': {
-              example: 'dumb',
-            },
-          },
-          description: 'descr 200',
-          headers: {
-            'fake-header-name-200': {},
-          },
-        },
-      }),
+      ),
     ).toMatchSnapshot();
   });
 
   it('given a response with nullish headers in dictionary should translate', () => {
     expect(
-      translateToResponses({
-        200: {
-          headers: {
-            '0': null,
+      translateToResponses(
+        {},
+        {
+          200: {
+            headers: {
+              '0': null,
+            },
           },
         },
-      }),
+      ),
     ).toStrictEqual([
       {
         code: '200',
@@ -69,12 +75,15 @@ describe('translateToOas3Responses', () => {
 
   it('should skip nullish responses', () => {
     expect(
-      translateToResponses({
-        200: null,
-        201: {
-          description: 'description 201',
+      translateToResponses(
+        {},
+        {
+          200: null,
+          201: {
+            description: 'description 201',
+          },
         },
-      }),
+      ),
     ).toStrictEqual([
       {
         code: '201',

--- a/src/oas3/transformers/responses.ts
+++ b/src/oas3/transformers/responses.ts
@@ -6,28 +6,30 @@ import {
   IMediaTypeContent,
   Optional,
 } from '@stoplight/types';
-import { compact, map } from 'lodash';
+import { compact, map, partial } from 'lodash';
 import { OpenAPIObject } from 'openapi3-ts';
 
 import { isDictionary, maybeResolveLocalRef } from '../../utils';
 import { isResponseObject } from '../guards';
 import { translateHeaderObject, translateMediaTypeObject } from './content';
 
-function responseTransformer(document: DeepPartial<OpenAPIObject>) {
-  return function translateToResponse(response: unknown, statusCode: string): Optional<IHttpOperationResponse> {
-    response = maybeResolveLocalRef(document, response);
-    if (!isResponseObject(response)) return;
+function translateToResponse(
+  document: DeepPartial<OpenAPIObject>,
+  response: unknown,
+  statusCode: string,
+): Optional<IHttpOperationResponse> {
+  response = maybeResolveLocalRef(document, response);
+  if (!isResponseObject(response)) return;
 
-    return {
-      code: statusCode,
-      description: response.description,
-      headers: compact<IHttpHeaderParam>(
-        map<Dictionary<unknown> & unknown, Optional<IHttpHeaderParam>>(response.headers, translateHeaderObject),
-      ),
-      contents: compact<IMediaTypeContent>(
-        map<Dictionary<unknown> & unknown, Optional<IMediaTypeContent>>(response.content, translateMediaTypeObject),
-      ),
-    };
+  return {
+    code: statusCode,
+    description: response.description,
+    headers: compact<IHttpHeaderParam>(
+      map<Dictionary<unknown> & unknown, Optional<IHttpHeaderParam>>(response.headers, translateHeaderObject),
+    ),
+    contents: compact<IMediaTypeContent>(
+      map<Dictionary<unknown> & unknown, Optional<IMediaTypeContent>>(response.content, translateMediaTypeObject),
+    ),
   };
 }
 
@@ -40,6 +42,6 @@ export function translateToResponses(
   }
 
   return compact<IHttpOperationResponse>(
-    map<Dictionary<unknown>, Optional<IHttpOperationResponse>>(responses, responseTransformer(document)),
+    map<Dictionary<unknown>, Optional<IHttpOperationResponse>>(responses, partial(translateToResponse, document)),
   );
 }

--- a/src/oas3/transformers/responses.ts
+++ b/src/oas3/transformers/responses.ts
@@ -18,17 +18,20 @@ function translateToResponse(
   response: unknown,
   statusCode: string,
 ): Optional<IHttpOperationResponse> {
-  response = maybeResolveLocalRef(document, response);
-  if (!isResponseObject(response)) return;
+  const resolvedResponse = maybeResolveLocalRef(document, response);
+  if (!isResponseObject(resolvedResponse)) return;
 
   return {
     code: statusCode,
-    description: response.description,
+    description: resolvedResponse.description,
     headers: compact<IHttpHeaderParam>(
-      map<Dictionary<unknown> & unknown, Optional<IHttpHeaderParam>>(response.headers, translateHeaderObject),
+      map<Dictionary<unknown> & unknown, Optional<IHttpHeaderParam>>(resolvedResponse.headers, translateHeaderObject),
     ),
     contents: compact<IMediaTypeContent>(
-      map<Dictionary<unknown> & unknown, Optional<IMediaTypeContent>>(response.content, translateMediaTypeObject),
+      map<Dictionary<unknown> & unknown, Optional<IMediaTypeContent>>(
+        resolvedResponse.content,
+        translateMediaTypeObject,
+      ),
     ),
   };
 }

--- a/src/oas3/transformers/servers.ts
+++ b/src/oas3/transformers/servers.ts
@@ -1,4 +1,4 @@
-import { DeepPartial, Dictionary, INodeVariable, IServer } from '@stoplight/types';
+import type { DeepPartial, Dictionary, INodeVariable, IServer } from '@stoplight/types';
 import { map, mapValues, pickBy } from 'lodash';
 import { ServerObject, ServerVariableObject } from 'openapi3-ts';
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
-import { pathToPointer, pointerToPath } from '@stoplight/json';
+import { hasRef, pathToPointer, pointerToPath } from '@stoplight/json';
 import { Dictionary, Optional } from '@stoplight/types';
-import { isObjectLike, map } from 'lodash';
+import { get, isObjectLike, map } from 'lodash';
 import * as URIJS from 'urijs';
 
 export function mapToKeys<T>(collection: Optional<T[]>) {
@@ -54,3 +54,15 @@ export function URI(url: string | URI = '') {
 
 export const isDictionary = (maybeDictionary: unknown): maybeDictionary is Dictionary<unknown> =>
   isObjectLike(maybeDictionary);
+
+export const getLocalRefValue = (document: unknown, $ref: string): unknown => {
+  return get(document, pointerToPath($ref));
+};
+
+export const maybeResolveLocalRef = (document: unknown, target: unknown): unknown => {
+  if (hasRef(target)) {
+    return getLocalRefValue(document, target.$ref);
+  }
+
+  return target;
+};


### PR DESCRIPTION
Fixes https://github.com/stoplightio/platform-internal/issues/3039
Fixes https://github.com/stoplightio/platform-internal/issues/2946

Due to new bundle strategy, incoming documents might have local $refs in them. We need to handle this case.

After these changes (compare to screenshots in 3039 linked above):

Note nice params and responses in righthand preview:

<img width="1758" alt="Screen Shot 2020-06-15 at 5 07 07 PM" src="https://user-images.githubusercontent.com/847542/84707691-c5c61d00-af24-11ea-8442-f69148f070e7.png">

Same thing, nice params and responses:

<img width="1704" alt="Screen Shot 2020-06-15 at 5 05 42 PM" src="https://user-images.githubusercontent.com/847542/84707726-d8d8ed00-af24-11ea-8bca-3161560bf045.png">
