### PR TITLE
fix(oas): openapi-schema-to-json-schema may throw

### DIFF
--- a/src/oas3/transformers/__tests__/content.test.ts
+++ b/src/oas3/transformers/__tests__/content.test.ts
@@ -20,6 +20,26 @@ describe('translateMediaTypeObject', () => {
     });
   });
 
+  it('given invalid schema, should return nothing', () => {
+    expect(
+      translateMediaTypeObject(
+        {
+          schema: {
+            get properties() {
+              throw new Error('I am invalid');
+            },
+          },
+        },
+        'mediaType',
+      ),
+    ).toStrictEqual({
+      encodings: [],
+      examples: [],
+      mediaType: 'mediaType',
+      schema: void 0,
+    });
+  });
+
   it('given single example should translate to IHttpContent', () => {
     expect(
       translateMediaTypeObject(

--- a/src/oas3/transformers/__tests__/content.test.ts
+++ b/src/oas3/transformers/__tests__/content.test.ts
@@ -40,6 +40,22 @@ describe('translateMediaTypeObject', () => {
     });
   });
 
+  it('given non-object schema, should return nothing', () => {
+    expect(
+      translateMediaTypeObject(
+        {
+          schema: 'foo',
+        },
+        'mediaType',
+      ),
+    ).toStrictEqual({
+      encodings: [],
+      examples: [],
+      mediaType: 'mediaType',
+      schema: void 0,
+    });
+  });
+
   it('given single example should translate to IHttpContent', () => {
     expect(
       translateMediaTypeObject(

--- a/src/oas3/transformers/content.ts
+++ b/src/oas3/transformers/content.ts
@@ -110,13 +110,19 @@ export function translateMediaTypeObject(mediaObject: unknown, mediaType: string
 
   const { schema, encoding } = mediaObject;
 
-  const jsonSchema = schema
-    ? (toJsonSchema(schema, {
+  let jsonSchema: Optional<JSONSchema4>;
+
+  if (isObject(schema)) {
+    try {
+      jsonSchema = toJsonSchema(schema, {
         cloneSchema: true,
         strictMode: false,
         keepNotSupported: ['example', 'deprecated', 'readOnly', 'writeOnly', 'xml', 'externalDocs'],
-      }) as JSONSchema4)
-    : undefined;
+      }) as JSONSchema4;
+    } catch (ex) {
+      // happens
+    }
+  }
 
   const example = mediaObject.example || jsonSchema?.example;
   const examples = mediaObject.examples;

--- a/src/oas3/transformers/content.ts
+++ b/src/oas3/transformers/content.ts
@@ -119,7 +119,7 @@ export function translateMediaTypeObject(mediaObject: unknown, mediaType: string
         strictMode: false,
         keepNotSupported: ['example', 'deprecated', 'readOnly', 'writeOnly', 'xml', 'externalDocs'],
       }) as JSONSchema4;
-    } catch (ex) {
+    } catch {
       // happens
     }
   }


### PR DESCRIPTION

long story short - http-spec should never throw an error, otherwise X task in Y project won't succeed and ultimately no preview panel will be rendered for a given document or node.


This is occurring quite often: https://sentry.io/organizations/stoplightio/issues/1673691344/?project=1549141&query=is%3Aunresolved+properties&statsPeriod=14d
