### PR TITLE
fix: filter out foreign scopes

### DIFF
--- a/src/oas/__tests__/__snapshots__/operation.test.ts.snap
+++ b/src/oas/__tests__/__snapshots__/operation.test.ts.snap
@@ -398,10 +398,7 @@ Array [
           "flows": Object {
             "implicit": Object {
               "authorizationUrl": "https://petstore.swagger.io/oauth/dialog",
-              "scopes": Object {
-                "read:pets": "read your pets",
-                "write:pets": "modify pets in your account",
-              },
+              "scopes": Object {},
             },
           },
           "key": "petstore_auth",
@@ -552,10 +549,7 @@ Array [
           "flows": Object {
             "implicit": Object {
               "authorizationUrl": "https://petstore.swagger.io/oauth/dialog",
-              "scopes": Object {
-                "read:pets": "read your pets",
-                "write:pets": "modify pets in your account",
-              },
+              "scopes": Object {},
             },
           },
           "key": "petstore_auth",

--- a/src/oas2/__tests__/service.test.ts
+++ b/src/oas2/__tests__/service.test.ts
@@ -65,4 +65,25 @@ describe('oas2 service', () => {
       version: '',
     });
   });
+
+  it('filters out scopes', () => {
+    const document: Partial<Spec> = {
+      swagger: '2.0',
+      securityDefinitions: {
+        'API Key': {
+          type: 'oauth2',
+          flow: 'implicit',
+          authorizationUrl: '',
+          scopes: {
+            scope_1: '',
+            scope_2: '',
+          },
+        },
+      },
+      security: [{ 'API Key': ['scope_1'] }],
+    };
+
+    const transformed = transformOas2Service({ document });
+    expect(transformed).toHaveProperty(['security', 0, 'flows', 'implicit', 'scopes'], { scope_1: '' });
+  });
 });

--- a/src/oas2/accessors.ts
+++ b/src/oas2/accessors.ts
@@ -35,9 +35,9 @@ function getSecurity(
     return [];
   }
 
-  return map(security, (sec: any) => {
+  return map(security, sec => {
     return compact(
-      keys(sec).map((key: string) => {
+      keys(sec).map(key => {
         const def = definitions[key];
 
         if (isSecurityScheme(def)) {

--- a/src/oas3/__tests__/accessors.test.ts
+++ b/src/oas3/__tests__/accessors.test.ts
@@ -1,5 +1,3 @@
-import { SecuritySchemeObject } from 'openapi3-ts';
-
 import { getSecurities } from '../accessors';
 
 describe('getOas3Securities', () => {
@@ -14,7 +12,7 @@ describe('getOas3Securities', () => {
           securitySchemes: {
             scheme: {
               type: 'apiKey',
-            } as SecuritySchemeObject,
+            },
           },
         },
       }),
@@ -29,7 +27,7 @@ describe('getOas3Securities', () => {
           securitySchemes: {
             operationScheme: {
               type: 'apiKey',
-            } as SecuritySchemeObject,
+            },
           },
         },
       }),
@@ -51,7 +49,7 @@ describe('getOas3Securities', () => {
             securitySchemes: {
               specScheme: {
                 type: 'apiKey',
-              } as SecuritySchemeObject,
+              },
             },
           },
         },
@@ -76,10 +74,10 @@ describe('getOas3Securities', () => {
             securitySchemes: {
               operationScheme: {
                 type: 'http',
-              } as SecuritySchemeObject,
+              },
               specScheme: {
                 type: 'apiKey',
-              } as SecuritySchemeObject,
+              },
             },
           },
         },
@@ -104,10 +102,10 @@ describe('getOas3Securities', () => {
             securitySchemes: {
               operationScheme: {
                 type: 'http',
-              } as SecuritySchemeObject,
+              },
               specScheme: {
                 type: 'apiKey',
-              } as SecuritySchemeObject,
+              },
             },
           },
         },

--- a/src/oas3/__tests__/service.test.ts
+++ b/src/oas3/__tests__/service.test.ts
@@ -208,4 +208,32 @@ describe('oas3 service', () => {
       ],
     });
   });
+
+  it('filters out scopes', () => {
+    const document: Partial<OpenAPIObject> = {
+      openapi: '3.0.0',
+      components: {
+        schemas: {},
+        securitySchemes: {
+          'API Key': {
+            type: 'oauth2',
+            flows: {
+              implicit: {
+                authorizationUrl: '',
+                refreshUrl: '',
+                scopes: {
+                  scope_1: '',
+                  scope_2: '',
+                },
+              },
+            },
+          },
+        },
+      },
+      security: [{ 'API Key': ['scope_1'] }],
+    };
+
+    const transformed = transformOas3Service({ document });
+    expect(transformed).toHaveProperty(['security', 0, 'flows', 'implicit', 'scopes'], { scope_1: '' });
+  });
 });

--- a/src/oas3/__tests__/service.test.ts
+++ b/src/oas3/__tests__/service.test.ts
@@ -15,11 +15,7 @@ describe('oas3 service', () => {
       },
     };
 
-    expect(
-      transformOas3Service({
-        document,
-      }),
-    ).toStrictEqual({
+    expect(transformOas3Service({ document })).toStrictEqual({
       id: '?http-service-id?',
       name: 'no-title',
       version: '',
@@ -71,11 +67,7 @@ describe('oas3 service', () => {
       },
     },
   ])('should handle lacking flows for oauth2 security object', document => {
-    expect(
-      transformOas3Service({
-        document,
-      }),
-    ).toStrictEqual({
+    expect(transformOas3Service({ document })).toStrictEqual({
       id: '?http-service-id?',
       name: 'no-title',
       version: '',
@@ -94,11 +86,7 @@ describe('oas3 service', () => {
       servers: 2 as any,
     };
 
-    expect(
-      transformOas3Service({
-        document,
-      }),
-    ).toStrictEqual({
+    expect(transformOas3Service({ document })).toStrictEqual({
       id: '?http-service-id?',
       name: 'no-title',
       version: '',
@@ -121,11 +109,7 @@ describe('oas3 service', () => {
       ],
     };
 
-    expect(
-      transformOas3Service({
-        document,
-      }),
-    ).toStrictEqual({
+    expect(transformOas3Service({ document })).toStrictEqual({
       id: '?http-service-id?',
       name: '',
       version: '1.0',

--- a/src/oas3/accessors.ts
+++ b/src/oas3/accessors.ts
@@ -1,9 +1,9 @@
 import type { DeepPartial, Dictionary, HttpSecurityScheme } from '@stoplight/types';
-import { isObject } from 'lodash';
-import { OpenAPIObject } from 'openapi3-ts';
+import { isObject, mapValues, pickBy } from 'lodash';
+import { OAuthFlowObject, OpenAPIObject } from 'openapi3-ts';
 
 import { mapToKeys } from '../utils';
-import { isSecuritySchemeWithKey } from './guards';
+import { isSecurityScheme, isSecuritySchemeWithKey } from './guards';
 
 export type OperationSecurities = Dictionary<string[], string>[] | undefined;
 export type SecurityWithKey = HttpSecurityScheme & { key: string };
@@ -12,7 +12,16 @@ export function getSecurities(
   document: DeepPartial<OpenAPIObject>,
   operationSecurity?: OperationSecurities,
 ): SecurityWithKey[][] {
-  const opSchemesPairs = operationSecurity ? mapToKeys(operationSecurity) : mapToKeys(document.security);
+  const opSchemesPairs = operationSecurity
+    ? mapToKeys(operationSecurity)
+    : document.security
+    ? mapToKeys(document.security)
+    : [];
+  const flattenPairs: Dictionary<string[]> = operationSecurity
+    ? Object.assign({}, ...operationSecurity)
+    : document.security
+    ? Object.assign({}, ...document.security)
+    : {};
   const definitions = document.components?.securitySchemes;
 
   if (!isObject(definitions)) return [];
@@ -20,7 +29,17 @@ export function getSecurities(
   return opSchemesPairs.map(opSchemePair =>
     opSchemePair
       .map(opScheme => {
-        return { ...definitions[opScheme], key: opScheme };
+        const definition = definitions[opScheme];
+
+        if (isSecurityScheme(definition) && definition.type === 'oauth2') {
+          // Put back only the flows that are part of the current definition
+          definition.flows = mapValues(definition.flows, (flow: OAuthFlowObject) => ({
+            ...flow,
+            scopes: pickBy(flow.scopes, (key: string) => flattenPairs[opScheme].includes(key)),
+          }));
+        }
+
+        return { ...definition, key: opScheme };
       })
       .filter(isSecuritySchemeWithKey),
   );

--- a/src/oas3/accessors.ts
+++ b/src/oas3/accessors.ts
@@ -33,10 +33,14 @@ export function getSecurities(
 
         if (isSecurityScheme(definition) && definition.type === 'oauth2') {
           // Put back only the flows that are part of the current definition
-          definition.flows = mapValues(definition.flows, (flow: OAuthFlowObject) => ({
-            ...flow,
-            scopes: pickBy(flow.scopes, (key: string) => flattenPairs[opScheme].includes(key)),
-          }));
+          return {
+            ...definition,
+            flows: mapValues(definition.flows, (flow: OAuthFlowObject) => ({
+              ...flow,
+              scopes: pickBy(flow.scopes, (key: string) => flattenPairs[opScheme].includes(key)),
+            })),
+            key: opScheme,
+          };
         }
 
         return { ...definition, key: opScheme };

--- a/src/oas3/service.ts
+++ b/src/oas3/service.ts
@@ -58,6 +58,7 @@ export const transformOas3Service: Oas3HttpServiceTransformer = ({ document }) =
       return isSecurityScheme(definition) && transformToSingleSecurity(definition, key);
     }),
   );
+
   if (securitySchemes.length) {
     httpService.securitySchemes = securitySchemes;
   }

--- a/src/oas3/service.ts
+++ b/src/oas3/service.ts
@@ -66,13 +66,10 @@ export const transformOas3Service: Oas3HttpServiceTransformer = ({ document }) =
     flatMap(document.security, sec => {
       if (!sec) return null;
 
-      return keys(sec).map(key => {
-        return securitySchemes.find(securityScheme => {
-          return securityScheme.key === key;
-        });
-      });
+      return keys(sec).map(key => securitySchemes.find(securityScheme => securityScheme.key === key));
     }),
   );
+
   if (security.length) {
     httpService.security = security;
   }

--- a/src/oas3/service.ts
+++ b/src/oas3/service.ts
@@ -90,7 +90,7 @@ export const transformOas3Service: Oas3HttpServiceTransformer = ({ document }) =
   );
 
   if (security.length) {
-    //@ts-ignore
+    //@ts-ignore I hate doing this, but unfortunately Lodash types are (rightfully) very loose and put undefined when it can't happen
     httpService.security = security;
   }
 

--- a/src/oas3/transformers/__tests__/securities.test.ts
+++ b/src/oas3/transformers/__tests__/securities.test.ts
@@ -196,7 +196,7 @@ describe('securities', () => {
                 },
               },
             },
-            [{ 'implicit-flow-security': [] }],
+            [{ 'implicit-flow-security': ['value'] }],
           ),
         ).toEqual([
           [
@@ -229,7 +229,7 @@ describe('securities', () => {
                 },
               },
             },
-            [{ 'password-flow-security': [] }],
+            [{ 'password-flow-security': ['value'] }],
           ),
         ).toEqual([
           [
@@ -262,7 +262,7 @@ describe('securities', () => {
                 },
               },
             },
-            [{ 'clientCredentials-flow-security': [] }],
+            [{ 'clientCredentials-flow-security': ['value'] }],
           ),
         ).toEqual([
           [
@@ -296,7 +296,7 @@ describe('securities', () => {
                 },
               },
             },
-            [{ 'authorizationCode-flow-security': [] }],
+            [{ 'authorizationCode-flow-security': ['value'] }],
           ),
         ).toEqual([
           [
@@ -359,7 +359,7 @@ describe('securities', () => {
         expect(
           translateToSecurities(document, [
             { 'http-security': [] },
-            { 'implicit-security': [] },
+            { 'implicit-security': ['value'] },
             { 'api-security': [] },
           ]),
         ).toEqual([
@@ -392,7 +392,9 @@ describe('securities', () => {
 
       it('AND relation between security schemes', () => {
         expect(
-          translateToSecurities(document, [{ 'http-security': [], 'implicit-security': [], 'api-security': [] }]),
+          translateToSecurities(document, [
+            { 'http-security': [], 'implicit-security': ['value'], 'api-security': [] },
+          ]),
         ).toEqual([
           [
             {


### PR DESCRIPTION
This PR will make sure that only the scopes that are defined in the operation security scope will be effectively copied in the final operation.

I am open to better alternatives to implement the filter.