### PR TITLE
feat: support oas3 x examples

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:12
     steps:
       - checkout
       - run: yarn
@@ -11,7 +11,7 @@ jobs:
       - run: yarn test --maxWorkers=2
   build:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:12
     steps:
       - checkout
       - run: yarn
@@ -19,7 +19,7 @@ jobs:
 
   release:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:12
     steps:
       - checkout
       - run: yarn

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "**/*"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "scripts": {
     "build": "sl-scripts build",

--- a/src/oas3/__tests__/getExamplesFromSchema.test.ts
+++ b/src/oas3/__tests__/getExamplesFromSchema.test.ts
@@ -1,3 +1,5 @@
+import { JSONSchema4 } from 'json-schema';
+
 import { getExamplesFromSchema } from '../transformers/getExamplesFromSchema';
 
 describe('getExamplesFromSchema', () => {
@@ -41,9 +43,26 @@ describe('getExamplesFromSchema', () => {
       ],
     });
   });
+
+  it('should ignore work with example', () => {
+    expect(
+      getExamplesFromSchema({
+        example: {
+          deviceID: '123',
+          deviceName: 'frontDoorLock',
+        },
+        schema: {},
+      }),
+    ).toEqual({
+      default: {
+        deviceID: '123',
+        deviceName: 'frontDoorLock',
+      },
+    });
+  });
 });
 
-const schema = {
+const schema: JSONSchema4 = {
   title: 'Device',
   type: 'object',
   'x-tags': ['devices', 'IOT'],

--- a/src/oas3/__tests__/getExamplesFromSchema.test.ts
+++ b/src/oas3/__tests__/getExamplesFromSchema.test.ts
@@ -10,53 +10,58 @@ describe('getExamplesFromSchema', () => {
 
   it('should work with x-examples', () => {
     expect(getExamplesFromSchema(schema)).toEqual({
-      devices: [
-        {
-          deviceID: '123',
-          deviceName: 'frontDoorLock',
-          deviceClass: 'safety',
-          spaceID: 'home',
-          alexaCompatible: true,
-          storageUsed: 0.003,
-          storageFree: 1,
-        },
-        {
-          deviceID: '789',
-          deviceName: 'sprinkler',
-          deviceClass: 'convenience',
-          spaceID: 'yard',
-          alexaCompatible: false,
-          storageUsed: 0.0018,
-          storageFree: 1,
-        },
-      ],
-      device: [
-        {
-          deviceID: 'abc',
-          deviceName: 'welcomeDroid',
-          deviceClass: 'commercial',
-          spaceID: 'office',
-          alexaCompatible: true,
-          storageUsed: 137,
-          storageFree: 300,
-        },
-      ],
+      devices: {
+        value: [
+          {
+            deviceID: '123',
+            deviceName: 'frontDoorLock',
+            deviceClass: 'safety',
+            spaceID: 'home',
+            alexaCompatible: true,
+            storageUsed: 0.003,
+            storageFree: 1,
+          },
+          {
+            deviceID: '789',
+            deviceName: 'sprinkler',
+            deviceClass: 'convenience',
+            spaceID: 'yard',
+            alexaCompatible: false,
+            storageUsed: 0.0018,
+            storageFree: 1,
+          },
+        ],
+      },
+      device: {
+        value: [
+          {
+            deviceID: 'abc',
+            deviceName: 'welcomeDroid',
+            deviceClass: 'commercial',
+            spaceID: 'office',
+            alexaCompatible: true,
+            storageUsed: 137,
+            storageFree: 300,
+          },
+        ],
+      },
     });
   });
 
-  it('should ignore work with example', () => {
+  it('should work with example', () => {
     expect(
       getExamplesFromSchema({
         example: {
           deviceID: '123',
           deviceName: 'frontDoorLock',
         },
-        schema: {},
       }),
     ).toEqual({
       default: {
-        deviceID: '123',
-        deviceName: 'frontDoorLock',
+        value: {
+          deviceID: '123',
+          deviceName: 'frontDoorLock',
+        },
       },
     });
   });

--- a/src/oas3/__tests__/getExamplesFromSchema.test.ts
+++ b/src/oas3/__tests__/getExamplesFromSchema.test.ts
@@ -3,11 +3,6 @@ import { JSONSchema4 } from 'json-schema';
 import { getExamplesFromSchema } from '../transformers/getExamplesFromSchema';
 
 describe('getExamplesFromSchema', () => {
-  it('should ignore invalid data', () => {
-    // @ts-ignore
-    expect(getExamplesFromSchema(null)).toEqual({});
-  });
-
   it('should work with x-examples', () => {
     expect(getExamplesFromSchema(schema)).toEqual({
       devices: {

--- a/src/oas3/__tests__/getExamplesFromSchema.test.ts
+++ b/src/oas3/__tests__/getExamplesFromSchema.test.ts
@@ -1,0 +1,85 @@
+import { getExamplesFromSchema } from '../transformers/getExamplesFromSchema';
+
+describe('getExamplesFromSchema', () => {
+  it('should ignore invalid data', () => {
+    // @ts-ignore
+    expect(getExamplesFromSchema(null)).toEqual({});
+  });
+
+  it('should work with x-examples', () => {
+    expect(getExamplesFromSchema(schema)).toEqual({
+      devices: [
+        {
+          deviceID: '123',
+          deviceName: 'frontDoorLock',
+          deviceClass: 'safety',
+          spaceID: 'home',
+          alexaCompatible: true,
+          storageUsed: 0.003,
+          storageFree: 1,
+        },
+        {
+          deviceID: '789',
+          deviceName: 'sprinkler',
+          deviceClass: 'convenience',
+          spaceID: 'yard',
+          alexaCompatible: false,
+          storageUsed: 0.0018,
+          storageFree: 1,
+        },
+      ],
+      device: [
+        {
+          deviceID: 'abc',
+          deviceName: 'welcomeDroid',
+          deviceClass: 'commercial',
+          spaceID: 'office',
+          alexaCompatible: true,
+          storageUsed: 137,
+          storageFree: 300,
+        },
+      ],
+    });
+  });
+});
+
+const schema = {
+  title: 'Device',
+  type: 'object',
+  'x-tags': ['devices', 'IOT'],
+  description:
+    'Describes a device activated on a **CloudHome** account. Each class can contain more than one device and location, centrally managed by the CloudHome service cloud.',
+  'x-examples': {
+    devices: [
+      {
+        deviceID: '123',
+        deviceName: 'frontDoorLock',
+        deviceClass: 'safety',
+        spaceID: 'home',
+        alexaCompatible: true,
+        storageUsed: 0.003,
+        storageFree: 1,
+      },
+      {
+        deviceID: '789',
+        deviceName: 'sprinkler',
+        deviceClass: 'convenience',
+        spaceID: 'yard',
+        alexaCompatible: false,
+        storageUsed: 0.0018,
+        storageFree: 1,
+      },
+    ],
+    device: [
+      {
+        deviceID: 'abc',
+        deviceName: 'welcomeDroid',
+        deviceClass: 'commercial',
+        spaceID: 'office',
+        alexaCompatible: true,
+        storageUsed: 137,
+        storageFree: 300,
+      },
+    ],
+  },
+};

--- a/src/oas3/transformers/__tests__/content.test.ts
+++ b/src/oas3/transformers/__tests__/content.test.ts
@@ -285,6 +285,22 @@ describe('translateMediaTypeObject', () => {
           ),
         ).toHaveProperty('examples', [{ key: 'default', value: defaultExample }]);
       });
+
+      it('should translate to IHttpContent with x-examples', () => {
+        expect(
+          translateMediaTypeObject(
+            {
+              schema: {
+                'x-examples': {
+                  foo: defaultExample,
+                },
+              },
+              encoding: {},
+            },
+            'mediaType',
+          ),
+        ).toHaveProperty('examples', [{ key: 'foo', value: defaultExample }]);
+      });
     });
 
     describe('given response with examples in media and schema objects', () => {

--- a/src/oas3/transformers/content.ts
+++ b/src/oas3/transformers/content.ts
@@ -125,8 +125,8 @@ export function translateMediaTypeObject(mediaObject: unknown, mediaType: string
     }
   }
 
-  const example = getExamplesFromSchema(mediaObject) || (jsonSchema && getExamplesFromSchema(jsonSchema));
-  const examples = getExamplesFromSchema(mediaObject);
+  const example = mediaObject.example;
+  const examples = mediaObject.examples || (jsonSchema ? getExamplesFromSchema(jsonSchema) : void 0);
 
   return {
     mediaType,

--- a/src/oas3/transformers/content.ts
+++ b/src/oas3/transformers/content.ts
@@ -15,6 +15,7 @@ import { EncodingPropertyObject, HeaderObject, MediaTypeObject } from 'openapi3-
 
 import { isDictionary } from '../../utils';
 import { isHeaderObject } from '../guards';
+import { getExamplesFromSchema } from './getExamplesFromSchema';
 
 function translateEncodingPropertyObject(
   encodingPropertyObject: EncodingPropertyObject,
@@ -124,8 +125,8 @@ export function translateMediaTypeObject(mediaObject: unknown, mediaType: string
     }
   }
 
-  const example = mediaObject.example || jsonSchema?.example;
-  const examples = mediaObject.examples;
+  const example = getExamplesFromSchema(mediaObject) || (jsonSchema && getExamplesFromSchema(jsonSchema));
+  const examples = getExamplesFromSchema(mediaObject);
 
   return {
     mediaType,

--- a/src/oas3/transformers/getExamplesFromSchema.ts
+++ b/src/oas3/transformers/getExamplesFromSchema.ts
@@ -5,12 +5,13 @@ import { Schema } from 'swagger-schema-official';
 
 export function getExamplesFromSchema(
   data: (Schema | JSONSchema4) & { 'x-examples'?: Dictionary<unknown> },
-): Dictionary<unknown> {
+): Dictionary<{ value: unknown }> {
   if (!isObject(data)) return {};
 
   return {
-    ...('example' in data && { default: data.example }),
-    ...('examples' in data && { default: data.examples }),
-    ...('x-examples' in data && isObject(data['x-examples']) && { ...data['x-examples'] }),
+    ...('example' in data && { default: { value: data.example } }),
+    ...('x-examples' in data &&
+      isObject(data['x-examples']) &&
+      Object.fromEntries(Object.entries(data['x-examples']).map(([key, val]) => [key, { value: val }]))),
   };
 }

--- a/src/oas3/transformers/getExamplesFromSchema.ts
+++ b/src/oas3/transformers/getExamplesFromSchema.ts
@@ -1,0 +1,16 @@
+import { Dictionary } from '@stoplight/types';
+import { JSONSchema4 } from 'json-schema';
+import { isObject } from 'lodash';
+import { Schema } from 'swagger-schema-official';
+
+export function getExamplesFromSchema(
+  data: (Schema | JSONSchema4) & { 'x-examples'?: Dictionary<unknown> },
+): Dictionary<unknown> {
+  if (!isObject(data)) return {};
+
+  return {
+    ...('example' in data && { default: data.example }),
+    ...('examples' in data && { default: data.examples }),
+    ...('x-examples' in data && isObject(data['x-examples']) && { ...data['x-examples'] }),
+  };
+}


### PR DESCRIPTION
Related Issue: https://github.com/stoplightio/platform-internal/issues/3331

* Common model examples are now reusable in OAS3 apis