### PR TITLE
fix(oas): security flows transformation is incorrect

### DIFF
--- a/src/oas2/guards.ts
+++ b/src/oas2/guards.ts
@@ -1,9 +1,10 @@
-import { Dictionary } from '@stoplight/types';
 import { isObject } from 'lodash';
 import type { Response, Security, Tag } from 'swagger-schema-official';
 
+import { isDictionary } from '../utils';
+
 export function isSecurityScheme(maybeSecurityScheme: unknown): maybeSecurityScheme is Security {
-  return isObject(maybeSecurityScheme) && typeof (maybeSecurityScheme as Dictionary<unknown>).type === 'string';
+  return isDictionary(maybeSecurityScheme) && typeof maybeSecurityScheme.type === 'string';
 }
 
 export const isTagObject = (maybeTagObject: unknown): maybeTagObject is Tag => {

--- a/src/oas2/transformers/securities.ts
+++ b/src/oas2/transformers/securities.ts
@@ -7,7 +7,7 @@ import {
   IOauth2SecurityScheme,
   IOauthFlowObjects,
 } from '@stoplight/types';
-import { compact } from 'lodash';
+import { isString, pickBy } from 'lodash';
 import {
   ApiKeySecurity,
   OAuth2AccessCodeSecurity,
@@ -18,22 +18,22 @@ import {
   Spec,
 } from 'swagger-schema-official';
 
+import { SecurityWithKey } from '../../oas3/accessors';
+import { isDictionary } from '../../utils';
 import { getSecurities } from '../accessors';
+import { isSecurityScheme } from '../guards';
 
 /**
  * @param security the union with 'any' is purposeful. Passing strict types does not help much here,
  * because all these checks happen in runtime. I'm leaving 'Security' only for visibility.
  */
-function translateToFlows(
-  security: DeepPartial<
-    OAuth2AccessCodeSecurity | OAuth2ApplicationSecurity | OAuth2ImplicitSecurity | OAuth2PasswordSecurity
-  >,
-): IOauthFlowObjects {
+function translateToFlows(security: Dictionary<unknown>): IOauthFlowObjects {
   const flows: IOauthFlowObjects = {};
 
-  const scopes = (security.scopes as Dictionary<string>) || {};
-  const authorizationUrl = 'authorizationUrl' in security ? security.authorizationUrl || '' : '';
-  const tokenUrl = 'tokenUrl' in security ? security.tokenUrl || '' : '';
+  const scopes = isDictionary(security.scopes) ? pickBy<unknown, string>(security.scopes, isString) : {};
+  const authorizationUrl =
+    'authorizationUrl' in security && typeof security.authorizationUrl === 'string' ? security.authorizationUrl : '';
+  const tokenUrl = 'tokenUrl' in security && typeof security.tokenUrl === 'string' ? security.tokenUrl : '';
 
   if (security.flow === 'implicit') {
     flows.implicit = {
@@ -107,14 +107,16 @@ function translateToOauth2SecurityScheme(
   };
 }
 
-export function translateToSingleSecurity(security: DeepPartial<Security>, key: string) {
-  switch (security.type) {
-    case 'basic':
-      return translateToBasicSecurityScheme(security, key);
-    case 'apiKey':
-      return translateToApiKeySecurityScheme(security, key);
-    case 'oauth2':
-      return translateToOauth2SecurityScheme(security, key);
+export function translateToSingleSecurity(security: unknown, key: string) {
+  if (isSecurityScheme(security)) {
+    switch (security.type) {
+      case 'basic':
+        return translateToBasicSecurityScheme(security, key);
+      case 'apiKey':
+        return translateToApiKeySecurityScheme(security, key);
+      case 'oauth2':
+        return translateToOauth2SecurityScheme(security, key);
+    }
   }
 
   return;
@@ -125,5 +127,15 @@ export function translateToSecurities(
   operationSecurity: Dictionary<string[], string>[] | undefined,
 ): HttpSecurityScheme[][] {
   const securities = getSecurities(document, operationSecurity);
-  return securities.map(security => compact(security.map(sec => translateToSingleSecurity(sec, sec.key))));
+
+  return securities.map(security =>
+    security.reduce<SecurityWithKey[]>((transformedSecurities, sec) => {
+      const transformed = translateToSingleSecurity(sec, sec.key);
+      if (transformed) {
+        transformedSecurities.push(transformed);
+      }
+
+      return transformedSecurities;
+    }, []),
+  );
 }

--- a/src/oas3/guards.ts
+++ b/src/oas3/guards.ts
@@ -3,6 +3,7 @@ import { isObject } from 'lodash';
 import {
   BaseParameterObject,
   HeaderObject,
+  OAuthFlowObject,
   ResponseObject,
   SecuritySchemeObject,
   ServerObject,
@@ -10,6 +11,7 @@ import {
   TagObject,
 } from 'openapi3-ts';
 
+import { isDictionary } from '../utils';
 import { SecurityWithKey } from './accessors';
 
 export const isSecurityScheme = (maybeSecurityScheme: unknown): maybeSecurityScheme is SecuritySchemeObject =>
@@ -59,3 +61,6 @@ export const isResponseObject = (maybeResponseObject: unknown): maybeResponseObj
     'headers' in maybeResponseObject ||
     'content' in maybeResponseObject ||
     'links' in maybeResponseObject);
+
+export const isOAuthFlowObject = (maybeOAuthFlowObject: unknown): maybeOAuthFlowObject is OAuthFlowObject =>
+  isDictionary(maybeOAuthFlowObject) && isDictionary(maybeOAuthFlowObject.scopes);


### PR DESCRIPTION
We should really stop using `DeepPartial<Xyz>` pattern - this is incorrect for most of the time.
We usually don't validate the provided input in any way before operating on it.
Moreover, using `pickBy` is just not quite great IMHO when it comes to typings, same as `get` is.

`Object.assign` was removed as it clobbered typing and was tad inconsistent with the how oas2 was implemented.