### PR TITLE
test(oas3): update expected output

### DIFF
--- a/src/oas3/__tests__/operation.test.ts
+++ b/src/oas3/__tests__/operation.test.ts
@@ -754,6 +754,7 @@ describe('transformOas3Operation', () => {
               schema: {
                 $schema: 'http://json-schema.org/draft-04/schema#',
                 type: 'object',
+                properties: {},
               },
             },
           ],
@@ -799,6 +800,7 @@ describe('transformOas3Operation', () => {
               schema: {
                 $schema: 'http://json-schema.org/draft-04/schema#',
                 type: 'object',
+                properties: {},
               },
             },
           ],


### PR DESCRIPTION
The test was first introduced in #129, but empty `properties` are now preserved thanks to #130.
#130 didn't have all the changes from master, therefore the tests passed (the failing test didn't even exist on that branch)