### PR TITLE
fix: server scheme validation

### DIFF
--- a/src/oas2/guards.ts
+++ b/src/oas2/guards.ts
@@ -21,3 +21,7 @@ export const isResponseObject = (maybeResponseObject: unknown): maybeResponseObj
     'schema' in maybeResponseObject ||
     'headers' in maybeResponseObject ||
     'examples' in maybeResponseObject);
+
+export function isValidScheme(scheme: unknown) {
+  return typeof scheme === 'string' && /^[a-zA-Z]\w+$/.test(scheme);
+}

--- a/src/oas2/guards.ts
+++ b/src/oas2/guards.ts
@@ -23,5 +23,5 @@ export const isResponseObject = (maybeResponseObject: unknown): maybeResponseObj
     'examples' in maybeResponseObject);
 
 export function isValidScheme(scheme: unknown) {
-  return typeof scheme === 'string' && /^[a-zA-Z]\w+$/.test(scheme);
+  return typeof scheme === 'string' && ['http', 'https', 'ws', 'wss'].includes(scheme);
 }

--- a/src/oas2/transformers/__tests__/servers.test.ts
+++ b/src/oas2/transformers/__tests__/servers.test.ts
@@ -80,24 +80,22 @@ describe('translateToServers', () => {
     expect(translateToServers({ host: 'stoplight.io', basePath: '/base-path', schemes: 1 } as any, {})).toEqual([]);
     // covers TypeError: {value}.replace is not a function coming from URI.js
     expect(
-      translateToServers({ host: 'stoplight.io', basePath: '/base-path', schemes: [null, 'test'] as any }, {}),
-    ).toEqual([
-      {
-        url: 'test://stoplight.io/base-path',
-      },
-    ]);
+      translateToServers(
+        { host: 'stoplight.io', basePath: '/base-path', schemes: [null, 'test', 'http ', '1https'] as any },
+        {},
+      ),
+    ).toEqual([]);
   });
 
   it('should handle malformed operation scheme gracefully', () => {
     expect(translateToServers({ host: 'stoplight.io', basePath: '/base-path' }, { schemes: 1 } as any)).toEqual([]);
     // covers TypeError: {value}.replace is not a function coming from URI.js
     expect(
-      translateToServers({ host: 'stoplight.io', basePath: '/base-path' }, { schemes: [null, 'test'] as any }),
-    ).toEqual([
-      {
-        url: 'test://stoplight.io/base-path',
-      },
-    ]);
+      translateToServers(
+        { host: 'stoplight.io', basePath: '/base-path' },
+        { schemes: [null, 'test', 'http ', '1https'] as any },
+      ),
+    ).toEqual([]);
   });
 
   it('should handle invalid server host gracefully', () => {
@@ -115,9 +113,5 @@ describe('translateToServers', () => {
         url: 'https://stoplight.io',
       },
     ]);
-  });
-
-  it('given incorrect schemes it should not return its server', () => {
-    expect(translateToServers({ host: 'stoplight.io' }, { schemes: ['wrong http', '1https'] })).toEqual([]);
   });
 });

--- a/src/oas2/transformers/__tests__/servers.test.ts
+++ b/src/oas2/transformers/__tests__/servers.test.ts
@@ -116,4 +116,8 @@ describe('translateToServers', () => {
       },
     ]);
   });
+
+  it('given incorrect schemes it should not return its server', () => {
+    expect(translateToServers({ host: 'stoplight.io' }, { schemes: ['wrong http', '1https'] })).toEqual([]);
+  });
 });

--- a/src/oas2/transformers/servers.ts
+++ b/src/oas2/transformers/servers.ts
@@ -1,8 +1,8 @@
 import { DeepPartial, IServer } from '@stoplight/types';
-import { isString } from 'lodash';
 import { Operation, Spec } from 'swagger-schema-official';
 
 import { URI } from '../../utils';
+import { isValidScheme } from '../guards';
 
 export function translateToServers(spec: DeepPartial<Spec>, operation: DeepPartial<Operation>): IServer[] {
   if (typeof spec.host !== 'string' || spec.host.length === 0) {
@@ -16,7 +16,7 @@ export function translateToServers(spec: DeepPartial<Spec>, operation: DeepParti
 
   const hasBasePath = typeof spec.basePath === 'string' && spec.basePath.length > 0;
 
-  return schemes.filter(isString).map(scheme => {
+  return schemes.filter(isValidScheme).map(scheme => {
     let uri = URI().scheme(scheme).host(spec.host);
 
     if (hasBasePath) {


### PR DESCRIPTION
Fixes https://github.com/stoplightio/elements/issues/904

Validates server schemes against invalid characters (i.e. whitespaces or leading numbers) that would throw if passed to `URI`.