### PR TITLE
feat(oas3): support all we need for now except schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Stoplight needs a way to interact with these documents in a standardized way, an
 
 ## How's HTTP Spec formed?
 
-This repository contains *exclusively* converters functions that take OpenAPI v2, OpenAPI v3, or Postman Collection documents and transforms them into the [http-spec interface](https://github.com/stoplightio/types/blob/master/src/http-spec.ts).
+This repository contains *exclusively* converters functions that take OpenAPI v2, OpenAPI v3.x, or Postman Collection documents and transforms them into the [http-spec interface](https://github.com/stoplightio/types/blob/master/src/http-spec.ts).
 
 You can explore the whole structure by looking at the [IHttpService](https://github.com/stoplightio/types/blob/master/src/http-spec.ts#L10) definition and checking out its descendands. You'll probably notice that it resembles a lot the current OpenAPI 3.x specification, and that's on purpose. OpenAPI 3.0 has first support and we gracefully upgrade/downgrade the other specification formats to it.
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/urijs": "~1.19.9",
     "json-schema-generator": "^2.0.6",
     "lodash": "^4.17.15",
-    "openapi3-ts": "~1.4.0",
+    "openapi3-ts": "^2.0.1",
     "postman-collection": "^3.6.2",
     "type-is": "^1.6.18",
     "urijs": "~1.19.2"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@stoplight/json": "^3.10.2",
-    "@stoplight/types": "^11.9.0",
+    "@stoplight/types": "^11.10.0",
     "@types/swagger-schema-official": "~2.0.21",
     "@types/to-json-schema": "^0.2.0",
     "@types/type-is": "^1.6.3",

--- a/src/oas/operation.ts
+++ b/src/oas/operation.ts
@@ -5,25 +5,29 @@ import { Spec } from 'swagger-schema-official';
 
 import { HttpOperationTransformer } from '../types';
 
-const methods = ['get', 'post', 'put', 'delete', 'options', 'head', 'patch', 'trace'];
+const DEFAULT_METHODS = ['get', 'post', 'put', 'delete', 'options', 'head', 'patch', 'trace'];
 
 export function transformOasOperations(
   document: Spec | OpenAPIObject,
   transformer: HttpOperationTransformer<any>,
+  methods: string[] | null = DEFAULT_METHODS,
 ): IHttpOperation[] {
   const paths = keys(get(document, 'paths'));
 
   return flatten(
-    map(paths, path =>
-      keys(get(document, ['paths', path]))
-        .filter(pathKey => methods.includes(pathKey))
-        .map(method =>
-          transformer({
-            document,
-            path,
-            method,
-          }),
-        ),
-    ),
+    map(paths, path => {
+      let operations = keys(get(document, ['paths', path]));
+      if (methods !== null) {
+        operations = operations.filter(pathKey => methods.includes(pathKey));
+      }
+
+      return operations.map(method =>
+        transformer({
+          document,
+          path,
+          method,
+        }),
+      );
+    }),
   );
 }

--- a/src/oas3/__tests__/operation.test.ts
+++ b/src/oas3/__tests__/operation.test.ts
@@ -813,4 +813,51 @@ describe('transformOas3Operation', () => {
       tags: [],
     });
   });
+
+  describe('OAS 3.1 support', () => {
+    it('should support pathItems', () => {
+      const document: Partial<OpenAPIObject> = {
+        openapi: '3.0.0',
+        paths: {
+          '/users/{userId}': {
+            $ref: '#/components/pathItems/userId',
+          },
+        },
+        components: {
+          pathItems: {
+            userId: {
+              get: {
+                responses: {
+                  '200': {
+                    content: {
+                      'application/json': {
+                        schema: {
+                          type: 'object',
+                          properties: {},
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      expect(
+        transformOas3Operation({
+          path: '/users/{userId}',
+          method: 'get',
+          document,
+        }),
+      ).toHaveProperty('responses', [
+        {
+          code: '200',
+          contents: expect.any(Array),
+          headers: expect.any(Array),
+        },
+      ]);
+    });
+  });
 });

--- a/src/oas3/__tests__/operation.test.ts
+++ b/src/oas3/__tests__/operation.test.ts
@@ -817,7 +817,7 @@ describe('transformOas3Operation', () => {
   describe('OAS 3.1 support', () => {
     it('should support pathItems', () => {
       const document: Partial<OpenAPIObject> = {
-        openapi: '3.0.0',
+        openapi: '3.1.0',
         paths: {
           '/users/{userId}': {
             $ref: '#/components/pathItems/userId',
@@ -858,6 +858,59 @@ describe('transformOas3Operation', () => {
           headers: expect.any(Array),
         },
       ]);
+    });
+
+    it('should support requestBodies on any method', () => {
+      const document: Partial<OpenAPIObject> = {
+        openapi: '3.1.0',
+        paths: {
+          '/subscribe': {
+            connect: {
+              operationId: 'opid',
+              responses: {},
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        id: {
+                          type: 'string',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      expect(
+        transformOas3Operation({
+          path: '/subscribe',
+          method: 'connect',
+          document,
+        }),
+      ).toHaveProperty('request.body', {
+        contents: [
+          {
+            encodings: [],
+            examples: [],
+            mediaType: 'application/json',
+            schema: {
+              $schema: 'http://json-schema.org/draft-04/schema#',
+              type: 'object',
+              properties: {
+                id: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        ],
+      });
     });
   });
 });

--- a/src/oas3/__tests__/service.test.ts
+++ b/src/oas3/__tests__/service.test.ts
@@ -209,7 +209,7 @@ describe('oas3 service', () => {
     });
   });
 
-  it('should filter out out scopes', () => {
+  it('should filter out scopes', () => {
     const document: Partial<OpenAPIObject> = {
       openapi: '3.0.0',
       components: {

--- a/src/oas3/__tests__/service.test.ts
+++ b/src/oas3/__tests__/service.test.ts
@@ -209,7 +209,7 @@ describe('oas3 service', () => {
     });
   });
 
-  it('filters out scopes', () => {
+  it('should filter out out scopes', () => {
     const document: Partial<OpenAPIObject> = {
       openapi: '3.0.0',
       components: {
@@ -235,5 +235,47 @@ describe('oas3 service', () => {
 
     const transformed = transformOas3Service({ document });
     expect(transformed).toHaveProperty(['security', 0, 'flows', 'implicit', 'scopes'], { scope_1: '' });
+  });
+
+  describe('OAS 3.1 support', () => {
+    it('should support info.summary', () => {
+      const document: Partial<OpenAPIObject> = {
+        info: {
+          title: '',
+          version: '1.0',
+          summary: 'Very cool API',
+        },
+      };
+
+      expect(transformOas3Service({ document })).toEqual({
+        id: '?http-service-id?',
+        name: '',
+        version: '1.0',
+        summary: 'Very cool API',
+      });
+    });
+
+    it('should support info.license.identifier', () => {
+      const document: Partial<OpenAPIObject> = {
+        info: {
+          title: '',
+          version: '1.0',
+          license: {
+            name: 'MIT License',
+            identifier: 'MIT',
+          },
+        },
+      };
+
+      expect(transformOas3Service({ document })).toEqual({
+        id: '?http-service-id?',
+        name: '',
+        version: '1.0',
+        license: {
+          name: 'MIT License',
+          identifier: 'MIT',
+        },
+      });
+    });
   });
 });

--- a/src/oas3/operation.ts
+++ b/src/oas3/operation.ts
@@ -20,11 +20,11 @@ export function transformOas3Operations(document: OpenAPIObject): IHttpOperation
 
 export const transformOas3Operation: Oas3HttpOperationTransformer = ({ document, path, method }) => {
   const pathObj = maybeResolveLocalRef(document, get(document, ['paths', path])) as PathsObject;
-  if (!pathObj) {
+  if (typeof pathObj !== 'object' || pathObj === null) {
     throw new Error(`Could not find ${['paths', path].join('/')} in the provided spec.`);
   }
 
-  const operation = maybeResolveLocalRef(document, get(document, ['paths', path, method])) as OperationObject;
+  const operation = maybeResolveLocalRef(document, pathObj[method]) as OperationObject;
   if (!operation) {
     throw new Error(`Could not find ${['paths', path, method].join('/')} in the provided spec.`);
   }

--- a/src/oas3/service.ts
+++ b/src/oas3/service.ts
@@ -13,18 +13,24 @@ export const transformOas3Service: Oas3HttpServiceTransformer = ({ document }) =
     name: document.info?.title ?? 'no-title',
   };
 
-  if (document.info?.description) {
+  if (typeof document.info?.description === 'string') {
     httpService.description = document.info.description;
+  }
+
+  if (typeof document.info?.summary === 'string') {
+    httpService.summary = document.info.summary;
   }
 
   if (document.info?.contact) {
     httpService.contact = document.info.contact;
   }
 
-  if (document.info?.license) {
+  if (typeof document.info?.license === 'object' && document.info.license !== null) {
+    const { name, identifier, ...license } = document.info.license;
     httpService.license = {
-      ...document.info.license,
-      name: document.info.license.name || '',
+      ...license,
+      name: typeof name === 'string' ? name : '',
+      ...(typeof identifier === 'string' && { identifier }),
     };
   }
 

--- a/src/oas3/transformers/__tests__/responses.test.ts
+++ b/src/oas3/transformers/__tests__/responses.test.ts
@@ -1,3 +1,6 @@
+import type { DeepPartial } from '@stoplight/types';
+import { OpenAPIObject } from 'openapi3-ts';
+
 import { translateToResponses } from '../responses';
 
 describe('translateToOas3Responses', () => {
@@ -95,7 +98,7 @@ describe('translateToOas3Responses', () => {
   });
 
   it('should resolve $refs nullish responses', () => {
-    const document = {
+    const document: DeepPartial<OpenAPIObject> = {
       openapi: '3.0.0',
       paths: {
         '/user': {
@@ -141,7 +144,7 @@ describe('translateToOas3Responses', () => {
       },
     };
 
-    expect(translateToResponses(document, document.paths['/user'].get.responses)).toEqual([
+    expect(translateToResponses(document, document.paths!['/user'].get.responses)).toEqual([
       {
         code: '200',
         contents: [

--- a/src/oas3/transformers/securities.ts
+++ b/src/oas3/transformers/securities.ts
@@ -21,7 +21,7 @@ export function translateToSecurities(document: DeepPartial<OpenAPIObject>, oper
 }
 
 export function transformToSingleSecurity(
-  securityScheme: SecuritySchemeObject,
+  securityScheme: SecuritySchemeObject | (Omit<SecuritySchemeObject, 'type'> & { type: 'mutualTLS' }),
   key: string,
 ): SecurityWithKey | undefined {
   const baseObject: { key: string; description?: string } = {
@@ -71,6 +71,13 @@ export function transformToSingleSecurity(
       ...baseObject,
       type: 'openIdConnect',
       openIdConnectUrl: securityScheme.openIdConnectUrl as string,
+    };
+  }
+
+  if (securityScheme.type === 'mutualTLS') {
+    return {
+      ...baseObject,
+      type: 'mutualTLS',
     };
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1018,10 +1018,10 @@
   resolved "https://registry.yarnpkg.com/@stoplight/test-utils/-/test-utils-0.0.1.tgz#b0d38c8a0abebda2dacbc2aa6a4f9bec44878e7b"
   integrity sha512-Cj3waLFR9bYLG8yvgkjXMxOfiVdewRyrKdH5RQpttVNfKj5UF+mElofPcHn/UfiOuxK3t5rbsdMfS26LK5tdQg==
 
-"@stoplight/types@^11.9.0":
-  version "11.9.0"
-  resolved "https://registry.yarnpkg.com/@stoplight/types/-/types-11.9.0.tgz#ced7de2dd53439d2409a3cb390bf7d5b76382ac6"
-  integrity sha512-4bzPpWZobt0e+d0OtALCJyl1HGzKo6ur21qxnId9dTl8v3yeD+5HJKZ2h1mv7e94debH5QDtimMU80V6jbXM8Q==
+"@stoplight/types@^11.10.0", "@stoplight/types@^11.9.0":
+  version "11.10.0"
+  resolved "https://registry.yarnpkg.com/@stoplight/types/-/types-11.10.0.tgz#60bbee770526f4de9cd1c613c7ab84c4e4674126"
+  integrity sha512-ffHD9i4UHS8Gsg7Ar8pKjI9B4kq7MRekE7tCROFGcFDzQhfRx9T92AduoLAtP/010XNYq23yDKpLBRPIEk8+xg==
   dependencies:
     "@types/json-schema" "^7.0.4"
     utility-types "^3.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6734,10 +6734,12 @@ onetime@^5.1.0:
   dependencies:
     mimic-fn "^2.1.0"
 
-openapi3-ts@~1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/openapi3-ts/-/openapi3-ts-1.4.0.tgz#679d5a24be0efc36f5de4fc2c4b8513663e16f65"
-  integrity sha512-8DmE2oKayvSkIR3XSZ4+pRliBsx19bSNeIzkTPswY8r4wvjX86bMxsORdqwAwMxE8PefOcSAT2auvi/0TZe9yA==
+openapi3-ts@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/openapi3-ts/-/openapi3-ts-2.0.1.tgz#b270aecea09e924f1886bc02a72608fca5a98d85"
+  integrity sha512-v6X3iwddhi276siej96jHGIqTx3wzVfMTmpGJEQDt7GPI7pI6sywItURLzpEci21SBRpPN/aOWSF5mVfFVNmcg==
+  dependencies:
+    yaml "^1.10.0"
 
 opencollective-postinstall@^2.0.2:
   version "2.0.2"
@@ -9412,6 +9414,11 @@ yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yaml@^1.10.0:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yaml@^1.7.2:
   version "1.8.2"


### PR DESCRIPTION
Addresses stoplightio/platform-internal#5776 

Needs https://github.com/stoplightio/types/pull/79

I didn't add tests for the following

> ensure that spaceDelimited and pipeDelimited are allowed on object type (rc0 Extended Functionality)

This is rather out of scope for `http-spec`. I'd say it's more of a Studio work, to make sure it's capable of generating a good example, i.e. http://spec.openapis.org/oas/v3.1.0#style-examples.
`http-spec` does not care what kind of type is given, it only cares about the style, and this is preserved.

> ensure that style, explode and allowReserved are allowed on multipart/form-data (rc0 Extended Functionality)

Reasoning: we don't seem to have such a need. This is how `IMediaTypeContent` looks like

```ts
export interface IHttpContent {
  schema?: JSONSchema4 | JSONSchema6 | JSONSchema7;
  examples?: (INodeExample | INodeExternalExample)[];
  encodings?: IHttpEncoding[];
}

export interface IMediaTypeContent extends IHttpContent {
  mediaType: string;
}
```

OAS 3.x.x already supports style, explode and allowReserved on `application/x-www-form-urlencoded`, but we ignore it, so I'm skeptical about adding it at this point, as we clearly do not need it yet.

See http://spec.openapis.org/oas/v3.0.0#fixed-fields-12