### PR TITLE
feat(oas3): support requestBody references

### DIFF
--- a/src/oas/__tests__/__snapshots__/operation.test.ts.snap
+++ b/src/oas/__tests__/__snapshots__/operation.test.ts.snap
@@ -375,9 +375,110 @@ Array [
     "path": "/pets",
     "request": Object {
       "body": Object {
-        "contents": Array [],
-        "description": undefined,
-        "required": undefined,
+        "contents": Array [
+          Object {
+            "encodings": Array [],
+            "examples": Array [],
+            "mediaType": "application/json",
+            "schema": Object {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "properties": Object {
+                "category": Object {
+                  "$ref": "#/components/schemas/Category",
+                },
+                "id": Object {
+                  "format": "int64",
+                  "maximum": 9223372036854776000,
+                  "minimum": -9223372036854776000,
+                  "type": "integer",
+                },
+                "name": Object {
+                  "example": "doggie",
+                  "type": "string",
+                },
+                "photoUrls": Object {
+                  "items": Object {
+                    "type": "string",
+                  },
+                  "type": "array",
+                  "xml": Object {
+                    "name": "photoUrl",
+                    "wrapped": true,
+                  },
+                },
+                "status": Object {
+                  "description": "pet status in the store",
+                  "enum": Array [
+                    "available",
+                    "pending",
+                    "sold",
+                  ],
+                  "type": "string",
+                },
+              },
+              "required": Array [
+                "name",
+                "photoUrls",
+              ],
+              "type": "object",
+              "xml": Object {
+                "name": "Pet",
+              },
+            },
+          },
+          Object {
+            "encodings": Array [],
+            "examples": Array [],
+            "mediaType": "application/xml",
+            "schema": Object {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "properties": Object {
+                "category": Object {
+                  "$ref": "#/components/schemas/Category",
+                },
+                "id": Object {
+                  "format": "int64",
+                  "maximum": 9223372036854776000,
+                  "minimum": -9223372036854776000,
+                  "type": "integer",
+                },
+                "name": Object {
+                  "example": "doggie",
+                  "type": "string",
+                },
+                "photoUrls": Object {
+                  "items": Object {
+                    "type": "string",
+                  },
+                  "type": "array",
+                  "xml": Object {
+                    "name": "photoUrl",
+                    "wrapped": true,
+                  },
+                },
+                "status": Object {
+                  "description": "pet status in the store",
+                  "enum": Array [
+                    "available",
+                    "pending",
+                    "sold",
+                  ],
+                  "type": "string",
+                },
+              },
+              "required": Array [
+                "name",
+                "photoUrls",
+              ],
+              "type": "object",
+              "xml": Object {
+                "name": "Pet",
+              },
+            },
+          },
+        ],
+        "description": "Pet object that needs to be added to the store",
+        "required": true,
       },
       "cookie": Array [],
       "headers": Array [],
@@ -499,9 +600,110 @@ Array [
     "path": "/pet/{petId}",
     "request": Object {
       "body": Object {
-        "contents": Array [],
-        "description": undefined,
-        "required": undefined,
+        "contents": Array [
+          Object {
+            "encodings": Array [],
+            "examples": Array [],
+            "mediaType": "application/json",
+            "schema": Object {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "properties": Object {
+                "category": Object {
+                  "$ref": "#/components/schemas/Category",
+                },
+                "id": Object {
+                  "format": "int64",
+                  "maximum": 9223372036854776000,
+                  "minimum": -9223372036854776000,
+                  "type": "integer",
+                },
+                "name": Object {
+                  "example": "doggie",
+                  "type": "string",
+                },
+                "photoUrls": Object {
+                  "items": Object {
+                    "type": "string",
+                  },
+                  "type": "array",
+                  "xml": Object {
+                    "name": "photoUrl",
+                    "wrapped": true,
+                  },
+                },
+                "status": Object {
+                  "description": "pet status in the store",
+                  "enum": Array [
+                    "available",
+                    "pending",
+                    "sold",
+                  ],
+                  "type": "string",
+                },
+              },
+              "required": Array [
+                "name",
+                "photoUrls",
+              ],
+              "type": "object",
+              "xml": Object {
+                "name": "Pet",
+              },
+            },
+          },
+          Object {
+            "encodings": Array [],
+            "examples": Array [],
+            "mediaType": "application/xml",
+            "schema": Object {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "properties": Object {
+                "category": Object {
+                  "$ref": "#/components/schemas/Category",
+                },
+                "id": Object {
+                  "format": "int64",
+                  "maximum": 9223372036854776000,
+                  "minimum": -9223372036854776000,
+                  "type": "integer",
+                },
+                "name": Object {
+                  "example": "doggie",
+                  "type": "string",
+                },
+                "photoUrls": Object {
+                  "items": Object {
+                    "type": "string",
+                  },
+                  "type": "array",
+                  "xml": Object {
+                    "name": "photoUrl",
+                    "wrapped": true,
+                  },
+                },
+                "status": Object {
+                  "description": "pet status in the store",
+                  "enum": Array [
+                    "available",
+                    "pending",
+                    "sold",
+                  ],
+                  "type": "string",
+                },
+              },
+              "required": Array [
+                "name",
+                "photoUrls",
+              ],
+              "type": "object",
+              "xml": Object {
+                "name": "Pet",
+              },
+            },
+          },
+        ],
+        "description": "Pet object that needs to be added to the store",
+        "required": true,
       },
       "cookie": Array [],
       "headers": Array [],

--- a/src/oas3/__tests__/operation.test.ts
+++ b/src/oas3/__tests__/operation.test.ts
@@ -814,6 +814,128 @@ describe('transformOas3Operation', () => {
     });
   });
 
+  it('should resolve requestBody reference to path operation requestBody', () => {
+    const document: Partial<OpenAPIObject> = {
+      openapi: '3.0.1',
+      info: {
+        title: 'title',
+        version: '',
+      },
+      paths: {
+        '/pets': {
+          post: {
+            requestBody: {
+              $ref: '#/paths/~1pets/put/requestBody',
+            },
+          },
+          put: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      id: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    expect(
+      transformOas3Operation({
+        path: '/pets',
+        method: 'post',
+        document,
+      }),
+    ).toHaveProperty('request.body', {
+      contents: [
+        {
+          encodings: [],
+          examples: [],
+          mediaType: 'application/json',
+          schema: {
+            $schema: 'http://json-schema.org/draft-04/schema#',
+            type: 'object',
+            properties: {
+              id: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  it('should resolve requestBody reference to components requestBodies', () => {
+    const document: Partial<OpenAPIObject> = {
+      openapi: '3.0.1',
+      info: {
+        title: 'title',
+        version: '',
+      },
+      paths: {
+        '/pets': {
+          post: {
+            requestBody: {
+              $ref: '#/components/requestBodies/Pet',
+            },
+          },
+        },
+      },
+      components: {
+        requestBodies: {
+          Pet: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    id: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    expect(
+      transformOas3Operation({
+        path: '/pets',
+        method: 'post',
+        document,
+      }),
+    ).toHaveProperty('request.body', {
+      contents: [
+        {
+          encodings: [],
+          examples: [],
+          mediaType: 'application/json',
+          schema: {
+            $schema: 'http://json-schema.org/draft-04/schema#',
+            type: 'object',
+            properties: {
+              id: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      ],
+    });
+  });
+
   describe('OAS 3.1 support', () => {
     it('should support pathItems', () => {
       const document: Partial<OpenAPIObject> = {

--- a/src/oas3/__tests__/operation.test.ts
+++ b/src/oas3/__tests__/operation.test.ts
@@ -936,6 +936,40 @@ describe('transformOas3Operation', () => {
     });
   });
 
+  it('should not fail if requestBody reference points to a falsy value', () => {
+    const document: Partial<OpenAPIObject> = {
+      openapi: '3.0.1',
+      info: {
+        title: 'title',
+        version: '',
+      },
+      paths: {
+        '/pets': {
+          post: {
+            requestBody: {
+              $ref: '#/components/requestBodies/Pet',
+            },
+          },
+        },
+      },
+      components: {
+        requestBodies: {
+          Pet: null as any,
+        },
+      },
+    };
+
+    expect(
+      transformOas3Operation({
+        path: '/pets',
+        method: 'post',
+        document,
+      }),
+    ).toHaveProperty('request.body', {
+      contents: [],
+    });
+  });
+
   describe('OAS 3.1 support', () => {
     it('should support pathItems', () => {
       const document: Partial<OpenAPIObject> = {

--- a/src/oas3/guards.ts
+++ b/src/oas3/guards.ts
@@ -4,6 +4,7 @@ import {
   BaseParameterObject,
   HeaderObject,
   OAuthFlowObject,
+  RequestBodyObject,
   ResponseObject,
   SecuritySchemeObject,
   ServerObject,
@@ -64,3 +65,6 @@ export const isResponseObject = (maybeResponseObject: unknown): maybeResponseObj
 
 export const isOAuthFlowObject = (maybeOAuthFlowObject: unknown): maybeOAuthFlowObject is OAuthFlowObject =>
   isDictionary(maybeOAuthFlowObject) && isDictionary(maybeOAuthFlowObject.scopes);
+
+export const isRequestBodyObject = (maybeRequestBodyObject: unknown): maybeRequestBodyObject is RequestBodyObject =>
+  isDictionary(maybeRequestBodyObject) && isDictionary(maybeRequestBodyObject.content);

--- a/src/oas3/transformers/request.ts
+++ b/src/oas3/transformers/request.ts
@@ -14,6 +14,7 @@ import type {
 import { compact, map, omit, partial, pickBy } from 'lodash';
 import type { OpenAPIObject, ParameterObject, RequestBodyObject } from 'openapi3-ts';
 
+import { isDictionary, maybeResolveLocalRef } from '../../utils';
 import { translateMediaTypeObject } from './content';
 
 function translateRequestBody(
@@ -69,11 +70,16 @@ export function translateToRequest(
     params[key].push(translateParameterObject(parameter));
   }
 
-  const body = requestBodyObject ? translateRequestBody(document, requestBodyObject) : { contents: [] };
+  let body;
+  if (isDictionary(requestBodyObject)) {
+    const resolvedRequestBodyObject = maybeResolveLocalRef(document, requestBodyObject) as RequestBodyObject;
+    body = translateRequestBody(document, resolvedRequestBodyObject);
+  } else {
+    body = { contents: [] };
+  }
 
   return {
     body,
-
     headers: params.header,
     query: params.query,
     cookie: params.cookie,

--- a/src/oas3/transformers/request.ts
+++ b/src/oas3/transformers/request.ts
@@ -15,6 +15,7 @@ import { compact, map, omit, partial, pickBy } from 'lodash';
 import type { OpenAPIObject, ParameterObject, RequestBodyObject } from 'openapi3-ts';
 
 import { isDictionary, maybeResolveLocalRef } from '../../utils';
+import { isRequestBodyObject } from '../guards';
 import { translateMediaTypeObject } from './content';
 
 function translateRequestBody(
@@ -73,7 +74,9 @@ export function translateToRequest(
   let body;
   if (isDictionary(requestBodyObject)) {
     const resolvedRequestBodyObject = maybeResolveLocalRef(document, requestBodyObject) as RequestBodyObject;
-    body = translateRequestBody(document, resolvedRequestBodyObject);
+    body = isRequestBodyObject(resolvedRequestBodyObject)
+      ? translateRequestBody(document, resolvedRequestBodyObject)
+      : { contents: [] };
   } else {
     body = { contents: [] };
   }


### PR DESCRIPTION
Addresses https://github.com/stoplightio/platform-internal/issues/5189

This PR adds support for references in the `requestBody` of operation object with corresponding tests. Also it fixes some snapshots where this feature was dropped intentionally.

According to [OAS3 Specification](http://spec.openapis.org/oas/v3.0.0#fixed-fields-7) operation object's `requestBody` can be a [Reference Object](http://spec.openapis.org/oas/v3.0.0#referenceObject).