### PR TITLE
feat(oas): minor adjustments to OAS Schema Object converter

### DIFF
--- a/src/oas/__tests__/__snapshots__/operation.test.ts.snap
+++ b/src/oas/__tests__/__snapshots__/operation.test.ts.snap
@@ -192,6 +192,7 @@ Array [
             "name": "X-Rate-Limit",
             "schema": Object {
               "$schema": "http://json-schema.org/draft-07/schema#",
+              "format": "int64",
               "maximum": 9223372036854776000,
               "minimum": -9223372036854776000,
               "type": "number",
@@ -403,6 +404,7 @@ Array [
                   "$ref": "#/components/schemas/Category",
                 },
                 "id": Object {
+                  "format": "int64",
                   "maximum": 9223372036854776000,
                   "minimum": -9223372036854776000,
                   "type": "integer",
@@ -454,6 +456,7 @@ Array [
                   "$ref": "#/components/schemas/Category",
                 },
                 "id": Object {
+                  "format": "int64",
                   "maximum": 9223372036854776000,
                   "minimum": -9223372036854776000,
                   "type": "integer",
@@ -632,6 +635,7 @@ Array [
                   "$ref": "#/components/schemas/Category",
                 },
                 "id": Object {
+                  "format": "int64",
                   "maximum": 9223372036854776000,
                   "minimum": -9223372036854776000,
                   "type": "integer",
@@ -683,6 +687,7 @@ Array [
                   "$ref": "#/components/schemas/Category",
                 },
                 "id": Object {
+                  "format": "int64",
                   "maximum": 9223372036854776000,
                   "minimum": -9223372036854776000,
                   "type": "integer",

--- a/src/oas/transformers/schema/__tests__/schema.spec.ts
+++ b/src/oas/transformers/schema/__tests__/schema.spec.ts
@@ -71,24 +71,53 @@ describe('translateSchemaObject', () => {
       anyOf: [
         {
           type: 'integer',
+          format: 'int64',
           minimum: 0 - 2 ** 63,
           maximum: 2 ** 40,
         },
         {
           type: 'integer',
+          format: 'int32',
           minimum: 0,
           maximum: 2 ** 31 - 1,
         },
         {
           type: 'number',
+          format: 'float',
           minimum: 0 - 2 ** 128,
           maximum: 2 ** 128 - 1,
         },
         {
           type: 'string',
+          format: 'byte',
           pattern: '^[\\w\\d+\\/=]*$',
         },
       ],
+    });
+  });
+
+  it('should keep properties using keywords as keys', () => {
+    expect(
+      translate({
+        properties: {
+          exclusiveMinimum: {
+            type: 'integer',
+          },
+          minimum: {
+            type: 'number',
+          },
+        },
+      }),
+    ).toStrictEqual({
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      properties: {
+        exclusiveMinimum: {
+          type: 'integer',
+        },
+        minimum: {
+          type: 'number',
+        },
+      },
     });
   });
 

--- a/src/oas/transformers/schema/index.ts
+++ b/src/oas/transformers/schema/index.ts
@@ -1,5 +1,5 @@
 import { DeepPartial } from '@stoplight/types';
-import type { JSONSchema7 } from 'json-schema';
+import type { JSONSchema4, JSONSchema6, JSONSchema7 } from 'json-schema';
 import { isObject } from 'lodash';
 import { OpenAPIObject } from 'openapi3-ts';
 import { Spec } from 'swagger-schema-official';
@@ -13,10 +13,10 @@ type InternalOptions = {
   structs: string[];
 };
 
-// Convert from OpenAPI 2.0 & OpenAPI 3.0 `SchemaObject` to JSON Schema Draft 7
+// Convert from OpenAPI 2.0, OpenAPI 3.0 `SchemaObject` or JSON Schema Draft4/6 to JSON Schema Draft 7
 // This converter shouldn't make any differences to Schema objects defined in OpenAPI 3.1, excepts when jsonSchemaDialect is provided.
 export function translateSchemaObject(
-  document: DeepPartial<Spec | OpenAPIObject>,
+  document: DeepPartial<Spec | OpenAPIObject | JSONSchema4 | JSONSchema6>,
   schema: OASSchemaObject,
 ): JSONSchema7 {
   if ('jsonSchemaDialect' in document && typeof document.jsonSchemaDialect === 'string') {
@@ -29,7 +29,7 @@ export function translateSchemaObject(
   }
 
   const clonedSchema = convertSchema(schema, {
-    structs: ['allOf', 'anyOf', 'oneOf', 'not', 'items', 'additionalProperties'],
+    structs: ['allOf', 'anyOf', 'oneOf', 'not', 'items', 'additionalProperties', 'additionalItems'],
   });
 
   clonedSchema.$schema = 'http://json-schema.org/draft-07/schema#';

--- a/src/oas/transformers/schema/keywords/format.ts
+++ b/src/oas/transformers/schema/keywords/format.ts
@@ -34,10 +34,12 @@ const convertFormatBase64: Converter = schema => {
   // Matches `standard` base64 not `base64url`. The specification does not
   // exclude it but current ongoing OpenAPI plans will distinguish btoh.
   (schema as JSONSchema7).contentEncoding = 'base64';
+  delete schema.format;
 };
 
 const convertFormatBinary: Converter = schema => {
   (schema as JSONSchema7).contentMediaType = 'application/octet-stream';
+  delete schema.format;
 };
 
 function asActualNumber(maybeNumber: unknown, defaultValue: number): number {
@@ -60,7 +62,6 @@ const formatConverters = {
 const format: Converter = schema => {
   if (typeof schema.format === 'string' && schema.format in formatConverters) {
     formatConverters[schema.format](schema);
-    delete schema.format;
   }
 };
 

--- a/src/oas3/__tests__/operation.test.ts
+++ b/src/oas3/__tests__/operation.test.ts
@@ -558,6 +558,7 @@ describe('transformOas3Operation', () => {
             schema: {
               $schema: 'http://json-schema.org/draft-07/schema#',
               type: 'string',
+              format: 'int32',
               maximum: 2147483647,
               minimum: -2147483648,
               examples: ['test'],


### PR DESCRIPTION
For https://github.com/stoplightio/platform-internal/pull/6083

List of changes:
- numeric `format` keywords are preserved
- we convert `additionalItems` - just in case
-  typings were tweaked a bit to indicate JSON Schema Draft 4 & Draft 6 are generally accepted.
