### PR TITLE
fix: add parameter example to examples list

### DIFF
--- a/src/oas3/__tests__/operation.test.ts
+++ b/src/oas3/__tests__/operation.test.ts
@@ -601,8 +601,12 @@ describe('transformOas3Operation', () => {
         cookie: [],
         headers: [
           {
-            example: 'test',
-            examples: [],
+            examples: [
+              {
+                key: '',
+                value: 'test',
+              },
+            ],
             name: 'name',
             schema: {
               $schema: 'http://json-schema.org/draft-07/schema#',
@@ -1149,8 +1153,7 @@ describe('transformOas3Operation', () => {
             cookie: [],
             headers: [
               {
-                example: 'test',
-                examples: [],
+                examples: [{ key: '', value: 'test' }],
                 name: 'email',
                 schema: {
                   $schema: 'https://json-schema.org/draft/2020-12/schema',

--- a/src/oas3/__tests__/operation.test.ts
+++ b/src/oas3/__tests__/operation.test.ts
@@ -603,8 +603,84 @@ describe('transformOas3Operation', () => {
           {
             examples: [
               {
-                key: '',
+                key: 'default',
                 value: 'test',
+              },
+            ],
+            name: 'name',
+            schema: {
+              $schema: 'http://json-schema.org/draft-07/schema#',
+              type: 'string',
+              format: 'int32',
+              maximum: 2147483647,
+              minimum: -2147483648,
+              examples: ['test'],
+            },
+          },
+        ],
+        path: [],
+        query: [],
+      },
+      responses: [],
+      security: [],
+      servers: [],
+      tags: [],
+    });
+  });
+
+  it('does not add default example if there is already one in examples', () => {
+    const document: Partial<OpenAPIObject> = {
+      openapi: '3',
+      info: {
+        title: 'title',
+        version: '',
+      },
+      paths: {
+        '/users/{userId}': {
+          get: {
+            parameters: [
+              {
+                in: 'header',
+                name: 'name',
+                schema: {
+                  type: 'string',
+                  format: 'int32',
+                },
+                example: 'test',
+                examples: {
+                  default: {
+                    value: 'some example',
+                  },
+                },
+              },
+              null,
+            ],
+          },
+        },
+      },
+    };
+
+    expect(
+      transformOas3Operation({
+        path: '/users/{userId}',
+        method: 'get',
+        document,
+      }),
+    ).toStrictEqual({
+      id: '?http-operation-id?',
+      method: 'get',
+      path: '/users/{userId}',
+      request: {
+        body: {
+          contents: [],
+        },
+        cookie: [],
+        headers: [
+          {
+            examples: [
+              {
+                key: 'default',
+                value: 'some example',
               },
             ],
             name: 'name',
@@ -1153,7 +1229,7 @@ describe('transformOas3Operation', () => {
             cookie: [],
             headers: [
               {
-                examples: [{ key: '', value: 'test' }],
+                examples: [{ key: 'default', value: 'test' }],
                 name: 'email',
                 schema: {
                   $schema: 'https://json-schema.org/draft/2020-12/schema',

--- a/src/oas3/transformers/request.ts
+++ b/src/oas3/transformers/request.ts
@@ -39,8 +39,13 @@ export function translateParameterObject(
   document: DeepPartial<OpenAPIObject>,
   parameterObject: ParameterObject,
 ): IHttpParam | any {
+  const examples = map(parameterObject.examples, (example, key) => ({
+    key,
+    ...example,
+  }));
+
   return pickBy({
-    ...omit(parameterObject, 'in', 'schema'),
+    ...omit(parameterObject, 'in', 'schema', 'example'),
     name: parameterObject.name,
     style: parameterObject.style,
     schema: isDictionary(parameterObject.schema)
@@ -49,10 +54,7 @@ export function translateParameterObject(
           ...('example' in parameterObject ? { example: parameterObject.example } : null),
         })
       : void 0,
-    examples: map(parameterObject.examples, (example, key) => ({
-      key,
-      ...example,
-    })),
+    examples: 'example' in parameterObject ? [{ key: '', value: parameterObject.example }, ...examples] : examples,
   });
 }
 

--- a/src/oas3/transformers/request.ts
+++ b/src/oas3/transformers/request.ts
@@ -44,6 +44,8 @@ export function translateParameterObject(
     ...example,
   }));
 
+  const hasDefaultExample = examples.map(({ key }) => key).includes('default');
+
   return pickBy({
     ...omit(parameterObject, 'in', 'schema', 'example'),
     name: parameterObject.name,
@@ -54,7 +56,10 @@ export function translateParameterObject(
           ...('example' in parameterObject ? { example: parameterObject.example } : null),
         })
       : void 0,
-    examples: 'example' in parameterObject ? [{ key: '', value: parameterObject.example }, ...examples] : examples,
+    examples:
+      'example' in parameterObject && !hasDefaultExample
+        ? [{ key: 'default', value: parameterObject.example }, ...examples]
+        : examples,
   });
 }
 


### PR DESCRIPTION
Fixes #154

Related to https://github.com/stoplightio/platform-internal/issues/6720 

2 questions:

- should I remove `example` parameter? I don't want to break stuff, but on the other hand it's not present in the IHttpParam interface at all. 🤷 
- do we have a good idea for the name of the key? `default`? `single`? Leave it blank? 🤔 