### PR TITLE
fix: dereferencing response headers objects before response assembling

### DIFF
--- a/src/oas3/transformers/__tests__/responses.test.ts
+++ b/src/oas3/transformers/__tests__/responses.test.ts
@@ -175,4 +175,58 @@ describe('translateToOas3Responses', () => {
       },
     ]);
   });
+
+  it('dereference headers', () => {
+    const translated = translateToResponses(
+      {
+        components: {
+          headers: {
+            xPage: {
+              schema: {
+                type: 'integer',
+              },
+              description: 'Current page (if pagination parameters were provided in the request)',
+              example: 3,
+            },
+          },
+        },
+      },
+      {
+        200: {
+          description: 'OK',
+          headers: {
+            'X-Page': {
+              $ref: '#/components/headers/xPage',
+            },
+          },
+        },
+      },
+    );
+
+    const expected = [
+      {
+        code: '200',
+        contents: [],
+        description: 'OK',
+        headers: [
+          {
+            name: 'X-Page',
+            schema: {
+              type: 'integer',
+            },
+            style: 'simple',
+            description: 'Current page (if pagination parameters were provided in the request)',
+            encodings: [],
+            examples: [
+              {
+                key: '__default',
+                value: 3,
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    expect(translated).toEqual(expected);
+  });
 });

--- a/src/oas3/transformers/responses.ts
+++ b/src/oas3/transformers/responses.ts
@@ -21,7 +21,7 @@ function translateToResponse(
   const resolvedResponse = maybeResolveLocalRef(document, response);
   if (!isResponseObject(resolvedResponse)) return;
 
-  const dereferenceddHeaders = reduce(
+  const dereferencedHeaders = reduce(
     resolvedResponse.headers,
     (result, header, name) => {
       return { ...result, [name]: maybeResolveLocalRef(document, header) };
@@ -32,7 +32,7 @@ function translateToResponse(
   return {
     code: statusCode,
     description: resolvedResponse.description,
-    headers: compact<IHttpHeaderParam>(map(dereferenceddHeaders, translateHeaderObject)),
+    headers: compact<IHttpHeaderParam>(map(dereferencedHeaders, translateHeaderObject)),
     contents: compact<IMediaTypeContent>(
       map<Dictionary<unknown> & unknown, Optional<IMediaTypeContent>>(
         resolvedResponse.content,

--- a/src/oas3/transformers/responses.ts
+++ b/src/oas3/transformers/responses.ts
@@ -6,7 +6,7 @@ import {
   IMediaTypeContent,
   Optional,
 } from '@stoplight/types';
-import { compact, map, partial } from 'lodash';
+import { compact, map, partial, reduce } from 'lodash';
 import { OpenAPIObject } from 'openapi3-ts';
 
 import { isDictionary, maybeResolveLocalRef } from '../../utils';
@@ -21,12 +21,18 @@ function translateToResponse(
   const resolvedResponse = maybeResolveLocalRef(document, response);
   if (!isResponseObject(resolvedResponse)) return;
 
+  const dereferenceddHeaders = reduce(
+    resolvedResponse.headers,
+    (result, header, name) => {
+      return { ...result, [name]: maybeResolveLocalRef(document, header) };
+    },
+    {},
+  );
+
   return {
     code: statusCode,
     description: resolvedResponse.description,
-    headers: compact<IHttpHeaderParam>(
-      map<Dictionary<unknown> & unknown, Optional<IHttpHeaderParam>>(resolvedResponse.headers, translateHeaderObject),
-    ),
+    headers: compact<IHttpHeaderParam>(map(dereferenceddHeaders, translateHeaderObject)),
     contents: compact<IMediaTypeContent>(
       map<Dictionary<unknown> & unknown, Optional<IMediaTypeContent>>(
         resolvedResponse.content,


### PR DESCRIPTION
Fixes the issue when a [header is set as $ref](https://spec.openapis.org/oas/v3.1.0#response-object)

```
 headers: {
            'X-Page': {
              $ref: '#/components/headers/xPage',
            },
          },
```


In this case, we need to dereference the header object first and then assemble response object.