### PR TITLE
feat: http operation extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@stoplight/json": "^3.10.2",
-    "@stoplight/types": "^12.3.0",
+    "@stoplight/types": "^12.4.0",
     "@types/swagger-schema-official": "~2.0.21",
     "@types/to-json-schema": "^0.2.0",
     "@types/type-is": "^1.6.3",

--- a/src/oas/__tests__/__snapshots__/operation.test.ts.snap
+++ b/src/oas/__tests__/__snapshots__/operation.test.ts.snap
@@ -4,6 +4,12 @@ exports[`oas operation openapi v2 1`] = `
 Array [
   Object {
     "description": "",
+    "extensions": Object {
+      "x-another": Object {
+        "property": "value",
+      },
+      "x-test": true,
+    },
     "id": "?http-operation-id?",
     "iid": "addPet",
     "method": "post",
@@ -74,6 +80,7 @@ Array [
     ],
   },
   Object {
+    "extensions": Object {},
     "id": "?http-operation-id?",
     "method": "get",
     "path": "/pets",
@@ -128,6 +135,7 @@ Array [
     "tags": Array [],
   },
   Object {
+    "extensions": Object {},
     "id": "?http-operation-id?",
     "method": "options",
     "path": "/pets",
@@ -205,6 +213,7 @@ Array [
   },
   Object {
     "description": "",
+    "extensions": Object {},
     "id": "?http-operation-id?",
     "method": "delete",
     "path": "/pets",
@@ -237,6 +246,7 @@ Array [
   },
   Object {
     "description": "",
+    "extensions": Object {},
     "id": "?http-operation-id?",
     "iid": "updatePet",
     "method": "put",
@@ -353,6 +363,12 @@ exports[`oas operation openapi v3 1`] = `
 Array [
   Object {
     "description": "",
+    "extensions": Object {
+      "x-another": Object {
+        "property": "value",
+      },
+      "x-test": true,
+    },
     "id": "?http-operation-id?",
     "iid": "addPet",
     "method": "post",
@@ -518,6 +534,7 @@ Array [
     ],
   },
   Object {
+    "extensions": Object {},
     "id": "?http-operation-id?",
     "method": "get",
     "path": "/pets",
@@ -584,6 +601,7 @@ Array [
   },
   Object {
     "description": "",
+    "extensions": Object {},
     "id": "?http-operation-id?",
     "iid": "updatePet",
     "method": "put",

--- a/src/oas/__tests__/fixtures/oas2-kitchen-sink.json
+++ b/src/oas/__tests__/fixtures/oas2-kitchen-sink.json
@@ -81,7 +81,11 @@
               "read:pets"
             ]
           }
-        ]
+        ],
+        "x-test": true,
+        "x-another": {
+          "property": "value"
+        }
       },
       "get": {
         "responses": {

--- a/src/oas/__tests__/fixtures/oas3-kitchen-sink.json
+++ b/src/oas/__tests__/fixtures/oas3-kitchen-sink.json
@@ -54,6 +54,10 @@
         ],
         "requestBody": {
           "$ref": "#/components/requestBodies/Pet"
+        },
+        "x-test": true,
+        "x-another": {
+          "property": "value"
         }
       },
       "get": {

--- a/src/oas/accessors.ts
+++ b/src/oas/accessors.ts
@@ -1,5 +1,5 @@
 import { Extensions } from '@stoplight/types';
-import { isObject, map, unionBy } from 'lodash';
+import { fromPairs, isObject, map, unionBy } from 'lodash';
 
 import { maybeResolveLocalRef } from '../utils';
 
@@ -30,7 +30,5 @@ export function getOasTags(tags: unknown): string[] {
 }
 
 export function getExtensions(target: Record<string, unknown>): Extensions {
-  return Object.fromEntries(
-    Object.entries(target).filter(([key]) => key.startsWith('x-') && !ROOT_EXTENSIONS.includes(key)),
-  );
+  return fromPairs(Object.entries(target).filter(([key]) => key.startsWith('x-') && !ROOT_EXTENSIONS.includes(key)));
 }

--- a/src/oas/accessors.ts
+++ b/src/oas/accessors.ts
@@ -5,6 +5,8 @@ import { maybeResolveLocalRef } from '../utils';
 
 type ParamTypeBase = { name: string; in: string };
 
+const ROOT_EXTENSIONS = ['x-internal'];
+
 export function getValidOasParameters<ParamType extends ParamTypeBase>(
   document: unknown,
   operationParameters: ParamType[] | undefined,
@@ -27,14 +29,8 @@ export function getOasTags(tags: unknown): string[] {
   return Array.isArray(tags) ? tags.filter(tag => typeof tag !== 'object').map(String) : [];
 }
 
-export function getExtensions(target: object): Extensions {
-  return Object.keys(target)
-    .filter(key => key.startsWith('x-'))
-    .reduce(
-      (obj, key) => ({
-        ...obj,
-        [key]: target[key],
-      }),
-      {},
-    );
+export function getExtensions(target: Record<string, unknown>): Extensions {
+  return Object.fromEntries(
+    Object.entries(target).filter(([key]) => key.startsWith('x-') && !ROOT_EXTENSIONS.includes(key)),
+  );
 }

--- a/src/oas/accessors.ts
+++ b/src/oas/accessors.ts
@@ -1,3 +1,4 @@
+import { Extensions } from '@stoplight/types';
 import { isObject, map, unionBy } from 'lodash';
 
 import { maybeResolveLocalRef } from '../utils';
@@ -24,4 +25,16 @@ const isValidOasParameter = (parameter: Partial<ParamTypeBase>): parameter is Pa
 
 export function getOasTags(tags: unknown): string[] {
   return Array.isArray(tags) ? tags.filter(tag => typeof tag !== 'object').map(String) : [];
+}
+
+export function getExtensions(target: object): Extensions {
+  return Object.keys(target)
+    .filter(key => key.startsWith('x-'))
+    .reduce(
+      (obj, key) => ({
+        ...obj,
+        [key]: target[key],
+      }),
+      {},
+    );
 }

--- a/src/oas2/__tests__/__snapshots__/operation.test.ts.snap
+++ b/src/oas2/__tests__/__snapshots__/operation.test.ts.snap
@@ -4,6 +4,7 @@ exports[`transformOas2Operation should translate operation 1`] = `
 Object {
   "deprecated": true,
   "description": "odesc",
+  "extensions": Object {},
   "id": "?http-operation-id?",
   "iid": "oid",
   "method": "get",

--- a/src/oas2/__tests__/operation.test.ts
+++ b/src/oas2/__tests__/operation.test.ts
@@ -146,17 +146,13 @@ describe('transformOas2Operation', () => {
         path: '/users/{userId}',
         method: 'get',
         internal: true,
-        extensions: {
-          'x-internal': true,
-        },
+        extensions: {},
       }),
       expect.objectContaining({
         path: '/users/{userId}',
         method: 'post',
         internal: false,
-        extensions: {
-          'x-internal': false,
-        },
+        extensions: {},
       }),
       {
         id: '?http-operation-id?',

--- a/src/oas2/__tests__/operation.test.ts
+++ b/src/oas2/__tests__/operation.test.ts
@@ -146,11 +146,17 @@ describe('transformOas2Operation', () => {
         path: '/users/{userId}',
         method: 'get',
         internal: true,
+        extensions: {
+          'x-internal': true,
+        },
       }),
       expect.objectContaining({
         path: '/users/{userId}',
         method: 'post',
         internal: false,
+        extensions: {
+          'x-internal': false,
+        },
       }),
       {
         id: '?http-operation-id?',
@@ -161,6 +167,7 @@ describe('transformOas2Operation', () => {
         security: [],
         servers: [],
         tags: [],
+        extensions: {},
       },
     ]);
   });
@@ -208,6 +215,7 @@ describe('transformOas2Operation', () => {
       security: [],
       servers: [],
       tags: [],
+      extensions: {},
     });
   });
 });

--- a/src/oas2/operation.ts
+++ b/src/oas2/operation.ts
@@ -2,7 +2,7 @@ import { IHttpOperation } from '@stoplight/types';
 import { get, isNil, omitBy } from 'lodash';
 import { Operation, Parameter, Path, Response, Spec } from 'swagger-schema-official';
 
-import { getOasTags, getValidOasParameters } from '../oas/accessors';
+import { getExtensions, getOasTags, getValidOasParameters } from '../oas/accessors';
 import { transformOasOperations } from '../oas/operation';
 import { translateToTags } from '../oas/tag';
 import { Oas2HttpOperationTransformer } from '../oas/types';
@@ -50,6 +50,7 @@ export const transformOas2Operation: Oas2HttpOperationTransformer = ({ document,
     ),
     tags: translateToTags(getOasTags(operation.tags)),
     security: translateToSecurities(document, operation.security),
+    extensions: getExtensions(operation),
   };
 
   return omitBy(httpOperation, isNil) as IHttpOperation;

--- a/src/oas2/operation.ts
+++ b/src/oas2/operation.ts
@@ -23,7 +23,9 @@ export const transformOas2Operation: Oas2HttpOperationTransformer = ({ document,
     throw new Error(`Could not find ${['paths', path].join('/')} in the provided spec.`);
   }
 
-  const operation = maybeResolveLocalRef(document, get(document, ['paths', path, method])) as Operation;
+  const operation = maybeResolveLocalRef(document, get(document, ['paths', path, method])) as Operation & {
+    [extension: string]: unknown;
+  };
   if (!operation) {
     throw new Error(`Could not find ${['paths', path, method].join('/')} in the provided spec.`);
   }
@@ -37,7 +39,7 @@ export const transformOas2Operation: Oas2HttpOperationTransformer = ({ document,
     iid: operation.operationId,
     description: operation.description,
     deprecated: operation.deprecated,
-    internal: operation['x-internal'],
+    internal: operation['x-internal'] as boolean,
     method,
     path,
     summary: operation.summary,

--- a/src/oas3/__tests__/__snapshots__/operation.test.ts.snap
+++ b/src/oas3/__tests__/__snapshots__/operation.test.ts.snap
@@ -5,6 +5,7 @@ Object {
   "callbacks": Array [
     Object {
       "callbackName": "myCallback",
+      "extensions": Object {},
       "id": "?http-operation-id?",
       "iid": "cbId",
       "method": "post",
@@ -24,6 +25,7 @@ Object {
       "tags": Array [],
     },
   ],
+  "extensions": Object {},
   "id": "?http-operation-id?",
   "iid": "opid",
   "method": "post",
@@ -65,6 +67,7 @@ exports[`transformOas3Operation given no tags should translate operation with em
 Object {
   "deprecated": true,
   "description": "descr",
+  "extensions": Object {},
   "id": "?http-operation-id?",
   "iid": "opid",
   "method": "get",
@@ -90,6 +93,7 @@ exports[`transformOas3Operation given operation servers should translate operati
 Object {
   "deprecated": true,
   "description": "descr",
+  "extensions": Object {},
   "id": "?http-operation-id?",
   "iid": "opid",
   "method": "get",
@@ -121,6 +125,7 @@ exports[`transformOas3Operation given path servers should translate operation wi
 Object {
   "deprecated": true,
   "description": "descr",
+  "extensions": Object {},
   "id": "?http-operation-id?",
   "iid": "opid",
   "method": "get",
@@ -152,6 +157,7 @@ exports[`transformOas3Operation given some tags should translate operation with 
 Object {
   "deprecated": true,
   "description": "descr",
+  "extensions": Object {},
   "id": "?http-operation-id?",
   "iid": "opid",
   "method": "get",
@@ -181,6 +187,7 @@ exports[`transformOas3Operation given spec servers should translate operation wi
 Object {
   "deprecated": true,
   "description": "descr",
+  "extensions": Object {},
   "id": "?http-operation-id?",
   "iid": "opid",
   "method": "get",

--- a/src/oas3/__tests__/operation.test.ts
+++ b/src/oas3/__tests__/operation.test.ts
@@ -90,17 +90,13 @@ describe('transformOas3Operation', () => {
         path: '/users/{userId}',
         method: 'get',
         internal: true,
-        extensions: {
-          'x-internal': true,
-        },
+        extensions: {},
       }),
       expect.objectContaining({
         path: '/users/{userId}',
         method: 'post',
         internal: false,
-        extensions: {
-          'x-internal': false,
-        },
+        extensions: {},
       }),
       {
         id: '?http-operation-id?',

--- a/src/oas3/__tests__/operation.test.ts
+++ b/src/oas3/__tests__/operation.test.ts
@@ -90,11 +90,17 @@ describe('transformOas3Operation', () => {
         path: '/users/{userId}',
         method: 'get',
         internal: true,
+        extensions: {
+          'x-internal': true,
+        },
       }),
       expect.objectContaining({
         path: '/users/{userId}',
         method: 'post',
         internal: false,
+        extensions: {
+          'x-internal': false,
+        },
       }),
       {
         id: '?http-operation-id?',
@@ -105,6 +111,7 @@ describe('transformOas3Operation', () => {
         security: [],
         servers: expect.any(Array),
         tags: [],
+        extensions: {},
       },
     ]);
   });
@@ -656,6 +663,7 @@ describe('transformOas3Operation', () => {
       security: [],
       servers: [],
       tags: [],
+      extensions: {},
     });
   });
 
@@ -732,6 +740,7 @@ describe('transformOas3Operation', () => {
       security: [],
       servers: [],
       tags: [],
+      extensions: {},
     });
   });
 
@@ -977,6 +986,7 @@ describe('transformOas3Operation', () => {
       security: [],
       servers: [],
       tags: [],
+      extensions: {},
     });
   });
 

--- a/src/oas3/operation.ts
+++ b/src/oas3/operation.ts
@@ -3,7 +3,7 @@ import { get, isNil, omitBy } from 'lodash';
 import type { OpenAPIObject, OperationObject, ParameterObject, PathsObject, RequestBodyObject } from 'openapi3-ts';
 
 import { transformOasOperations } from '../oas';
-import { getOasTags, getValidOasParameters } from '../oas/accessors';
+import { getExtensions, getOasTags, getValidOasParameters } from '../oas/accessors';
 import { translateToTags } from '../oas/tag';
 import { Oas3HttpOperationTransformer } from '../oas/types';
 import { maybeResolveLocalRef } from '../utils';
@@ -50,6 +50,7 @@ export const transformOas3Operation: Oas3HttpOperationTransformer = ({ document,
     callbacks: operation.callbacks && translateToCallbacks(operation.callbacks),
     tags: translateToTags(getOasTags(operation.tags)),
     security: translateToSecurities(document, operation.security),
+    extensions: getExtensions(operation),
   };
 
   return omitBy(httpOperation, isNil) as IHttpOperation;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1026,10 +1026,10 @@
     "@types/json-schema" "^7.0.4"
     utility-types "^3.10.0"
 
-"@stoplight/types@^12.3.0":
-  version "12.3.0"
-  resolved "https://registry.yarnpkg.com/@stoplight/types/-/types-12.3.0.tgz#ac71d295319f26abb279e3d89d1c1774857d20b4"
-  integrity sha512-hgzUR1z5BlYvIzUeFK5pjs5JXSvEutA9Pww31+dVicBlunsG1iXopDx/cvfBY7rHOrgtZDuvyeK4seqkwAZ6Cg==
+"@stoplight/types@^12.4.0":
+  version "12.4.0"
+  resolved "https://registry.yarnpkg.com/@stoplight/types/-/types-12.4.0.tgz#7a90e747d3f531742316b7b2969e6c45efd3e968"
+  integrity sha512-ELf0dOdROaKEE0iw1YF9qbL9QjIVfdyiCoBPpUQmvQej9F7tQR/TsYMvyUb8kz+rd49u3hGP/sirVuaTKI1ZOg==
   dependencies:
     "@types/json-schema" "^7.0.4"
     utility-types "^3.10.0"


### PR DESCRIPTION
Addresses: https://github.com/stoplightio/platform-internal/issues/7772
~Requires: https://github.com/stoplightio/types/pull/97~

Transforming operation `x-extensions` properties to `HttpOperation` `extensions` property.