### PR TITLE
fix: create security item for each scope

### DIFF
--- a/src/oas3/__tests__/accessors.test.ts
+++ b/src/oas3/__tests__/accessors.test.ts
@@ -113,4 +113,62 @@ describe('getOas3Securities', () => {
       ),
     ).toStrictEqual([[]]);
   });
+
+  it('should return security for each scope', () => {
+    const res = getSecurities(
+      {
+        components: {
+          securitySchemes: {
+            authWith2Scopes: {
+              type: 'oauth2',
+              flows: {
+                authorizationCode: {
+                  scopes: {
+                    accessToken: 'accessToken description',
+                    secScope: 'secScope description',
+                  },
+                },
+              },
+            },
+          },
+        },
+        security: [
+          {
+            authWith2Scopes: ['accessToken', 'secScope'],
+          },
+        ],
+      },
+      [
+        {
+          authWith2Scopes: ['accessToken'],
+        },
+        { authWith2Scopes: ['secScope'] },
+      ],
+    );
+
+    expect(res).toStrictEqual([
+      [
+        {
+          type: 'oauth2',
+          flows: {
+            authorizationCode: {
+              scopes: { accessToken: 'accessToken description' },
+            },
+          },
+          key: 'authWith2Scopes',
+        },
+      ],
+      [
+        {
+          type: 'oauth2',
+          flows: {
+            authorizationCode: {
+              scopes: { secScope: 'secScope description' },
+            },
+          },
+          key: 'authWith2Scopes',
+        },
+      ],
+    ]);
+  });
 });

--- a/src/oas3/accessors.ts
+++ b/src/oas3/accessors.ts
@@ -17,8 +17,8 @@ export function getSecurities(
 
   return (operationSecurities || document.security || []).map(operationSecurity => {
     return Object.entries(operationSecurity)
-      .map(([secSchemeKey, scopes]) => {
-        const definition = definitions[secSchemeKey];
+      .map(([opScheme, scopes]) => {
+        const definition = definitions[opScheme];
 
         if (isSecurityScheme(definition) && definition.type === 'oauth2') {
           // Put back only the flows that are part of the current definition
@@ -28,11 +28,11 @@ export function getSecurities(
               ...flow,
               scopes: pickBy(flow.scopes, (_val: string, key: string) => scopes?.includes(key)),
             })),
-            key: secSchemeKey,
+            key: opScheme,
           };
         }
 
-        return { ...definition, key: secSchemeKey };
+        return { ...definition, key: opScheme };
       })
       .filter(isSecuritySchemeWithKey);
   });

--- a/src/oas3/accessors.ts
+++ b/src/oas3/accessors.ts
@@ -2,7 +2,6 @@ import type { DeepPartial, Dictionary, HttpSecurityScheme } from '@stoplight/typ
 import { isObject, mapValues, pickBy } from 'lodash';
 import { OAuthFlowObject, OpenAPIObject } from 'openapi3-ts';
 
-import { mapToKeys } from '../utils';
 import { isSecurityScheme, isSecuritySchemeWithKey } from './guards';
 
 export type OperationSecurities = Dictionary<string[], string>[] | undefined;
@@ -10,26 +9,16 @@ export type SecurityWithKey = HttpSecurityScheme & { key: string };
 
 export function getSecurities(
   document: DeepPartial<OpenAPIObject>,
-  operationSecurity?: OperationSecurities,
+  operationSecurities?: OperationSecurities,
 ): SecurityWithKey[][] {
-  const opSchemesPairs = operationSecurity
-    ? mapToKeys(operationSecurity)
-    : document.security
-    ? mapToKeys(document.security)
-    : [];
-  const flattenPairs: Dictionary<string[]> = operationSecurity
-    ? Object.assign({}, ...operationSecurity)
-    : document.security
-    ? Object.assign({}, ...document.security)
-    : {};
   const definitions = document.components?.securitySchemes;
 
   if (!isObject(definitions)) return [];
 
-  return opSchemesPairs.map(opSchemePair =>
-    opSchemePair
-      .map(opScheme => {
-        const definition = definitions[opScheme];
+  return (operationSecurities || document.security || []).map(operationSecurity => {
+    return Object.entries(operationSecurity)
+      .map(([secSchemeKey, scopes]) => {
+        const definition = definitions[secSchemeKey];
 
         if (isSecurityScheme(definition) && definition.type === 'oauth2') {
           // Put back only the flows that are part of the current definition
@@ -37,14 +26,14 @@ export function getSecurities(
             ...definition,
             flows: mapValues(definition.flows, (flow: OAuthFlowObject) => ({
               ...flow,
-              scopes: pickBy(flow.scopes, (_val: string, key: string) => flattenPairs[opScheme].includes(key)),
+              scopes: pickBy(flow.scopes, (_val: string, key: string) => scopes?.includes(key)),
             })),
-            key: opScheme,
+            key: secSchemeKey,
           };
         }
 
-        return { ...definition, key: opScheme };
+        return { ...definition, key: secSchemeKey };
       })
-      .filter(isSecuritySchemeWithKey),
-  );
+      .filter(isSecuritySchemeWithKey);
+  });
 }


### PR DESCRIPTION
For stoplightio/platform-internal#9530

It makes sure security is created for each scope. I've removed mapping to keys and then looking in `flattenPairs` in `getSecurities` function for it to work. Why was this done in the first place, I don't know. Maybe there is some use case I'm not aware of? 
All tests are passing tho 🤷‍♂️ 