### PR TITLE
Change JSON schema generator to genson-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@types/swagger-schema-official": "~2.0.21",
     "@types/type-is": "^1.6.3",
     "fnv-plus": "^1.3.1",
-    "json-schema-generator": "^2.0.6",
+    "genson-js": "^0.0.8",
     "lodash.isequalwith": "^4.4.0",
     "lodash.pick": "^4.4.0",
     "lodash.pickby": "^4.6.0",

--- a/src/oas/transformers/schema/index.ts
+++ b/src/oas/transformers/schema/index.ts
@@ -47,7 +47,7 @@ export const translateSchemaObject = withContext<
   return cached;
 });
 
-export function convertSchema(document: Fragment, schema: OASSchemaObject) {
+export function convertSchema(document: Fragment, schema: OASSchemaObject | JSONSchema7): JSONSchema7 {
   if ('jsonSchemaDialect' in document && typeof document.jsonSchemaDialect === 'string') {
     return {
       $schema: document.jsonSchemaDialect,
@@ -62,11 +62,11 @@ export function convertSchema(document: Fragment, schema: OASSchemaObject) {
   });
 
   clonedSchema.$schema = 'http://json-schema.org/draft-07/schema#';
-  return clonedSchema as JSONSchema7;
+  return clonedSchema;
 }
 
-function _convertSchema(schema: OASSchemaObject, options: InternalOptions): JSONSchema7 {
-  const clonedSchema: OASSchemaObject | JSONSchema7 = { ...schema };
+function _convertSchema(schema: OASSchemaObject | JSONSchema7, options: InternalOptions): JSONSchema7 {
+  const clonedSchema = { ...schema };
 
   for (const struct of options.structs) {
     if (Array.isArray(clonedSchema[struct])) {
@@ -98,7 +98,7 @@ function _convertSchema(schema: OASSchemaObject, options: InternalOptions): JSON
   return clonedSchema as JSONSchema7;
 }
 
-function convertProperties(schema: OASSchemaObject, options: InternalOptions): void {
+function convertProperties(schema: OASSchemaObject | JSONSchema7, options: InternalOptions): void {
   const props = { ...schema.properties };
   schema.properties = props;
 

--- a/src/postman/transformers/__tests__/params.test.ts
+++ b/src/postman/transformers/__tests__/params.test.ts
@@ -106,10 +106,8 @@ describe('transformBody()', () => {
                   mediaType: 'application/nice+json',
                   schema: {
                     $schema: 'http://json-schema.org/draft-07/schema#',
-                    description: '',
                     properties: {
                       a: {
-                        minLength: 1,
                         type: 'string',
                       },
                     },

--- a/src/postman/transformers/__tests__/response.test.ts
+++ b/src/postman/transformers/__tests__/response.test.ts
@@ -40,10 +40,8 @@ describe('transformResponse()', () => {
             mediaType: 'application/json',
             schema: {
               $schema: 'http://json-schema.org/draft-07/schema#',
-              description: '',
               properties: {
                 "I'm a JSON": {
-                  minLength: 1,
                   type: 'string',
                 },
               },

--- a/src/postman/transformers/params.ts
+++ b/src/postman/transformers/params.ts
@@ -6,8 +6,8 @@ import {
   IHttpQueryParam,
   IMediaTypeContent,
 } from '@stoplight/types';
-import type { JSONSchema7 } from 'json-schema';
 import { createSchema } from 'genson-js';
+import type { JSONSchema7 } from 'json-schema';
 import type { FormParam, Header, PropertyList, QueryParam, RequestBody } from 'postman-collection';
 import * as typeIs from 'type-is';
 

--- a/src/postman/transformers/params.ts
+++ b/src/postman/transformers/params.ts
@@ -7,8 +7,7 @@ import {
   IMediaTypeContent,
 } from '@stoplight/types';
 import type { JSONSchema7 } from 'json-schema';
-// @ts-ignore
-import * as jsonSchemaGenerator from 'json-schema-generator';
+import { createSchema } from 'genson-js';
 import type { FormParam, Header, PropertyList, QueryParam, RequestBody } from 'postman-collection';
 import * as typeIs from 'type-is';
 
@@ -90,7 +89,7 @@ export function transformRawBody(raw: string, mediaType: string = 'text/plain'):
             value: parsed,
           },
         ],
-        schema: convertSchema({}, jsonSchemaGenerator(parsed)),
+        schema: convertSchema({}, createSchema(parsed)),
       };
     } catch (e) {
       /* noop, move on.. */


### PR DESCRIPTION
## Motivation and Context
The `json-schema-generator` dependency is not maintained anymore - it's been out of date for years, but it also has numerous security issues with its dependencies. There is another library, `gensons-js`, that is written in Typescript and is better maintained currently.

See https://github.com/stoplightio/prism/pull/2035 for an example of a dependency audit that can't fully resolve the security issues because of the version of `optimist` that `json-schema-generator` uses.

https://github.com/aspecto-io/genson-js

## Description
This change replaces the import and call to `jsonSchemaGenerator` with the `createSchema` function from `genson-js`. The main difference I found when testing is that when a string type is generated in the schema, there is no longer a `"minLength": 1` property added, meaning that empty strings are allowed in the schema. That doesn't seem like a huge issue, but it is probably a breaking change.

In addition, the types in the `convertSchema` function and associated functions used `OASSchemaObject` even though they would cast to `JSONSchema7`, so they were updated to use `OASSchemaObject | JSONSchema7`


## How Has This Been Tested?
Ran `yarn install`, `yarn build`, then `yarn test` and all the existing tests passed.


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ x ] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [ ] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [ x ] All new and existing tests pass locally (excluding flaky CI tests).
