### PR TITLE
fix(oas): translateSchemaObject does not handle circular references

### DIFF
--- a/src/oas/transformers/schema/__tests__/schema.spec.ts
+++ b/src/oas/transformers/schema/__tests__/schema.spec.ts
@@ -200,6 +200,29 @@ describe('translateSchemaObject', () => {
     });
   });
 
+  it('should handle circular references', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+        },
+        address: {
+          type: 'object',
+          properties: {
+            city: {},
+          },
+        },
+        location: {},
+      },
+    };
+
+    schema.properties.location = schema.properties.address;
+    schema.properties.address.properties.city = schema.properties.location;
+
+    expect(translate.bind(null, schema as OASSchemaObject)).not.toThrow();
+  });
+
   describe('OAS2 Schema Object', () => {
     it('should translate x-nullable', () => {
       expect(


### PR DESCRIPTION
Fixes https://github.com/stoplightio/platform-internal/issues/11303
It's not a new issue since this is how the old code used to work, but previously we didn't use `translateSchemaObject` in a few cases (which was an actual issue I fixed in 5.x), so perhaps that's where that increased error rate comes from.
Overall not a huge deal, but still good to get it addressed now that we use http-spec in even more spots.