### PR TITLE
fix(oas3): support externalValue in example objects

### DIFF
--- a/src/oas/__tests__/__snapshots__/operation.test.ts.snap
+++ b/src/oas/__tests__/__snapshots__/operation.test.ts.snap
@@ -680,7 +680,23 @@ Array [
         "contents": Array [
           Object {
             "encodings": Array [],
-            "examples": Array [],
+            "examples": Array [
+              Object {
+                "id": "97acd8b5018d8",
+                "key": "Dog",
+                "summary": "A dog example",
+                "value": Object {
+                  "name": "Leo",
+                  "photoUrls": Array [],
+                },
+              },
+              Object {
+                "externalValue": "https://stoplight.io/pets/cat",
+                "id": "97acd8b5018d8",
+                "key": "Cat",
+                "summary": "A cat example",
+              },
+            ],
             "id": "954d8d8652606",
             "mediaType": "application/json",
             "schema": Object {
@@ -941,7 +957,23 @@ Array [
         "contents": Array [
           Object {
             "encodings": Array [],
-            "examples": Array [],
+            "examples": Array [
+              Object {
+                "id": "97acd8b5018d8",
+                "key": "Dog",
+                "summary": "A dog example",
+                "value": Object {
+                  "name": "Leo",
+                  "photoUrls": Array [],
+                },
+              },
+              Object {
+                "externalValue": "https://stoplight.io/pets/cat",
+                "id": "97acd8b5018d8",
+                "key": "Cat",
+                "summary": "A cat example",
+              },
+            ],
             "id": "954d8d8652606",
             "mediaType": "application/json",
             "schema": Object {

--- a/src/oas/__tests__/fixtures/oas3-kitchen-sink.json
+++ b/src/oas/__tests__/fixtures/oas3-kitchen-sink.json
@@ -189,6 +189,19 @@
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/Pet"
+            },
+            "examples": {
+              "Dog": {
+                "summary": "A dog example",
+                "value": {
+                  "name": "Leo",
+                  "photoUrls": []
+                }
+              },
+              "Cat": {
+                "summary": "A cat example",
+                "externalValue": "https://stoplight.io/pets/cat"
+              }
             }
           },
           "application/xml": {

--- a/src/oas3/transformers/__tests__/__snapshots__/content.test.ts.snap
+++ b/src/oas3/transformers/__tests__/__snapshots__/content.test.ts.snap
@@ -16,6 +16,12 @@ Object {
       "value": "hey",
     },
     Object {
+      "externalValue": "https://stoplight.io/b",
+      "id": Any<String>,
+      "key": "b",
+      "summary": "example summary",
+    },
+    Object {
       "id": Any<String>,
       "key": "__default",
       "value": Object {},

--- a/src/oas3/transformers/__tests__/content.test.ts
+++ b/src/oas3/transformers/__tests__/content.test.ts
@@ -459,6 +459,10 @@ describe('translateHeaderObject', () => {
               summary: 'example summary',
               value: 'hey',
             },
+            b: {
+              summary: 'example summary',
+              externalValue: 'https://stoplight.io/b',
+            },
           },
           example: {},
           content: {},
@@ -468,6 +472,9 @@ describe('translateHeaderObject', () => {
     ).toMatchSnapshot({
       id: expect.any(String),
       examples: [
+        {
+          id: expect.any(String),
+        },
         {
           id: expect.any(String),
         },

--- a/src/oas3/transformers/__tests__/responses.test.ts
+++ b/src/oas3/transformers/__tests__/responses.test.ts
@@ -173,6 +173,9 @@ describe('translateToOas3Responses', () => {
                       'my-example': {
                         $ref: '#/components/examples/Joe',
                       },
+                      Bear: {
+                        externalValue: 'https://stoplight.io/bear',
+                      },
                     },
                   },
                 },
@@ -218,6 +221,11 @@ describe('translateToOas3Responses', () => {
                 value: {
                   id: 1,
                 },
+              },
+              {
+                id: expect.any(String),
+                key: 'Bear',
+                externalValue: 'https://stoplight.io/bear',
               },
             ],
             mediaType: 'application/json',

--- a/src/oas3/transformers/content.ts
+++ b/src/oas3/transformers/content.ts
@@ -5,6 +5,7 @@ import {
   IHttpHeaderParam,
   IMediaTypeContent,
   INodeExample,
+  INodeExternalExample,
   Optional,
 } from '@stoplight/types';
 import type { JSONSchema7 } from 'json-schema';
@@ -124,7 +125,7 @@ export const translateHeaderObject = withContext<
     ),
   };
 
-  const examples: INodeExample[] = [];
+  const examples: (INodeExample | INodeExternalExample)[] = [];
   const encodings: IHttpEncoding[] = [];
 
   if (isPlainObject(contentValue)) {

--- a/src/oas3/transformers/examples.ts
+++ b/src/oas3/transformers/examples.ts
@@ -1,5 +1,5 @@
 import { isPlainObject } from '@stoplight/json';
-import { INodeExample, Optional } from '@stoplight/types';
+import { INodeExample, INodeExternalExample, Optional } from '@stoplight/types';
 import pickBy = require('lodash.pickby');
 
 import { withContext } from '../../context';
@@ -9,7 +9,10 @@ import type { ArrayCallbackParameters } from '../../types';
 import type { Oas3TranslateFunction } from '../types';
 
 export const translateToExample = withContext<
-  Oas3TranslateFunction<ArrayCallbackParameters<[key: string, example: unknown]>, Optional<INodeExample>>
+  Oas3TranslateFunction<
+    ArrayCallbackParameters<[key: string, example: unknown]>,
+    Optional<INodeExample | INodeExternalExample>
+  >
 >(function ([key, example]) {
   const resolvedExample = this.maybeResolveLocalRef(example);
 
@@ -19,8 +22,11 @@ export const translateToExample = withContext<
 
   return {
     id: this.generateId(`example-${this.parentId}-${actualKey}`),
-    value: resolvedExample.value,
     key,
+
+    ...(typeof resolvedExample.externalValue === 'string'
+      ? { externalValue: resolvedExample.externalValue }
+      : { value: resolvedExample.value }),
 
     ...pickBy(
       {


### PR DESCRIPTION
Stumbled upon this one thanks to https://github.com/stoplightio/types/pull/108

Weird we haven't had `externalValue` anywhere in our fixtures, but I suppose it's not particularly common.

FWIW this one is also not a new bug, it's been there since always? That's how it looked like in 4.3.1 https://github.com/stoplightio/http-spec/blob/v4.3.1/src/oas3/transformers/content.ts#L169