### PR TITLE
feat: set internal property on http services

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "dependencies": {
     "@stoplight/json": "^3.18.1",
     "@stoplight/json-schema-generator": "1.0.1",
-    "@stoplight/types": "^13.5.0",
+    "@stoplight/types": "^13.6.0",
     "@types/json-schema": "7.0.11",
     "@types/swagger-schema-official": "~2.0.22",
     "@types/type-is": "^1.6.3",

--- a/src/oas/service.ts
+++ b/src/oas/service.ts
@@ -4,7 +4,7 @@ import pickBy = require('lodash.pickby');
 import { OpenAPIObject } from 'openapi3-ts';
 import { Spec } from 'swagger-schema-official';
 
-import { isNonNullable, isString } from '../guards';
+import { isBoolean, isNonNullable, isString } from '../guards';
 import { TranslateFunction } from '../types';
 import { hasXLogo } from './guards';
 import { translateTagDefinition } from './tags';
@@ -36,6 +36,13 @@ export const transformOasService: TranslateFunction<DeepPartial<OpenAPIObject> |
           contact: document.info?.contact,
         },
         isPlainObject,
+      ),
+
+      ...pickBy(
+        {
+          internal: document['x-internal'],
+        },
+        isBoolean,
       ),
     };
 

--- a/src/oas2/__tests__/service.test.ts
+++ b/src/oas2/__tests__/service.test.ts
@@ -92,6 +92,28 @@ describe('oas2 service', () => {
     const transformed = transformOas2Service({ document });
     expect(transformed).toHaveProperty(['security', 0, 'flows', 'implicit', 'scopes'], { scope_1: '' });
   });
+
+  it('should handle x-internal property', () => {
+    const document: Partial<Spec> & Fragment & { 'x-internal': boolean } = {
+      'x-stoplight': { id: 'abc' },
+      info: {
+        title: '',
+        version: '1.0',
+      },
+      'x-internal': true,
+    };
+
+    expect(
+      transformOas2Service({
+        document,
+      }),
+    ).toStrictEqual({
+      id: 'abc',
+      name: '',
+      version: '1.0',
+      internal: true,
+    });
+  });
   describe('x-logo support', () => {
     it('should support x-logo', () => {
       const document: Partial<OpenAPIObject> = {

--- a/src/oas3/__tests__/service.test.ts
+++ b/src/oas3/__tests__/service.test.ts
@@ -216,6 +216,23 @@ describe('oas3 service', () => {
     });
   });
 
+  it('should handle x-internal property', () => {
+    const document: Partial<OpenAPIObject> & { 'x-internal': boolean } = {
+      info: {
+        title: '',
+        version: '1.0',
+      },
+      'x-internal': true,
+    };
+
+    expect(transformOas3Service({ document })).toStrictEqual({
+      id: 'abc',
+      internal: true,
+      name: '',
+      version: '1.0',
+    });
+  });
+
   it('should filter out scopes', () => {
     const document: Partial<OpenAPIObject> = {
       openapi: '3.0.0',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1491,10 +1491,10 @@
     "@types/json-schema" "^7.0.4"
     utility-types "^3.10.0"
 
-"@stoplight/types@^13.5.0":
-  version "13.5.0"
-  resolved "https://registry.yarnpkg.com/@stoplight/types/-/types-13.5.0.tgz#a17990ab4ff3fc60325dc64d758c4670b872ac8b"
-  integrity sha512-8UFgYj4Y/vcc3a2ZuJJ+ltiJlFsXa7/huZkmjhaHq+jPHIR2Va+aFaExENV/cWtxUVTXE15KSzPOX/ikucUFbw==
+"@stoplight/types@^13.6.0":
+  version "13.6.0"
+  resolved "https://registry.yarnpkg.com/@stoplight/types/-/types-13.6.0.tgz#96c6aaae05858b36f589821cd52c95aa9b205ce7"
+  integrity sha512-dzyuzvUjv3m1wmhPfq82lCVYGcXG0xUYgqnWfCq3PCVR4BKFhjdkHrnJ+jIDoMKvXb05AZP/ObQF6+NpDo29IQ==
   dependencies:
     "@types/json-schema" "^7.0.4"
     utility-types "^3.10.0"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Transforms the 'x-internal' property in the oas document to internal.
Related to a change that was requested for this pr https://github.com/stoplightio/platform-internal/pull/12208
<!-- If it fixes an open issue, please link to the issue here. -->


## Description
<!-- Describe your technical changes in detail. -->


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Did you test the changes locally, in a PR environment, or somewhere else? -->
<!-- Were unit/integration/e2e/other tests added? If not, why? -->
<!-- Also describe how one or more persons giving a code review can verify your changes. -->


## Screenshot(s)/recordings(s)
<!-- If applicable, add screenshots or gifs to help demonstrate the changes. -->
<!-- If not applicable, remove this screenshots section before creating the PR. -->


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [ ] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [ ] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
