### PR TITLE
fix(oas): add setter so $refs can be set

### DIFF
--- a/src/oas/__tests__/operation.test.ts
+++ b/src/oas/__tests__/operation.test.ts
@@ -1,3 +1,4 @@
+import { bundleTarget } from '@stoplight/json';
 import { OpenAPIObject } from 'openapi3-ts';
 import { Spec } from 'swagger-schema-official';
 
@@ -23,5 +24,141 @@ describe('oas operation', () => {
 
     expect(result).toHaveLength(3);
     expect(result).toMatchSnapshot();
+  });
+
+  it('can be re-bundled', () => {
+    const document = {
+      openapi: '3.0.2',
+      info: {},
+      paths: {
+        '/update': {
+          put: {
+            summary: '/Update',
+            description: 'Post data requests to the Flow. Executors with `@requests(on="/update")` will respond.',
+            operationId: '_update_update_put',
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/components/schemas/JinaRequestModel',
+                  },
+                },
+              },
+              required: true,
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          JinaRequestModel: {
+            title: 'JinaRequestModel',
+            type: 'object',
+            properties: {
+              data: {
+                anyOf: [
+                  {
+                    type: 'array',
+                    items: {
+                      $ref: '#/components/schemas/PydanticDocument',
+                    },
+                  },
+                ],
+              },
+            },
+          },
+          PydanticDocument: {
+            title: 'PydanticDocument',
+            type: 'object',
+            properties: {
+              chunks: {
+                title: 'Chunks',
+                type: 'array',
+                items: {
+                  $ref: '#/components/schemas/PydanticDocument',
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const result = transformOas3Operations(document);
+
+    expect(
+      bundleTarget({
+        document: {
+          ...document,
+          __target__: result[0],
+        },
+        path: '#/__target__',
+        cloneDocument: false,
+      }),
+    ).toStrictEqual({
+      id: 'http_operation-undefined-put-/update',
+      iid: '_update_update_put',
+      method: 'put',
+      path: '/update',
+      description: 'Post data requests to the Flow. Executors with `@requests(on="/update")` will respond.',
+      request: {
+        body: {
+          id: 'http_request_body-http_operation-undefined-put-/update',
+          contents: [
+            {
+              id: 'http_media-http_request_body-http_operation-undefined-put-/update-application/json',
+              mediaType: 'application/json',
+              encodings: [],
+              examples: [],
+              schema: {
+                $schema: 'http://json-schema.org/draft-07/schema#',
+                properties: {
+                  data: {
+                    anyOf: [
+                      {
+                        items: {
+                          $ref: '#/__bundled__/PydanticDocument',
+                        },
+                        type: 'array',
+                      },
+                    ],
+                  },
+                },
+                title: 'JinaRequestModel',
+                type: 'object',
+                'x-stoplight': {
+                  id: 'schema-undefined-JinaRequestModel',
+                },
+              },
+            },
+          ],
+          required: true,
+        },
+        cookie: [],
+        headers: [],
+        path: [],
+        query: [],
+      },
+      extensions: {},
+      responses: [],
+      security: [],
+      servers: [],
+      summary: '/Update',
+      tags: [],
+      __bundled__: {
+        PydanticDocument: {
+          title: 'PydanticDocument',
+          type: 'object',
+          properties: {
+            chunks: {
+              title: 'Chunks',
+              type: 'array',
+              items: {
+                $ref: '#/__bundled__/PydanticDocument',
+              },
+            },
+          },
+        },
+      },
+    });
   });
 });

--- a/src/oas/resolver.ts
+++ b/src/oas/resolver.ts
@@ -72,5 +72,8 @@ export function syncReferenceObject<K extends Reference>(target: K, references: 
     get() {
       return getResolved(references, $ref);
     },
+    set(value) {
+      references[$ref] = { value, resolved: true };
+    },
   });
 }


### PR DESCRIPTION
discovered by https://github.com/stoplightio/prism/issues/2090
Prism runs `bundleTarget` on operations.
Would be cool to implement `bundleOas{2,3}Operation` same as we do with [bundleOas2Service](https://github.com/stoplightio/http-spec/blob/master/src/oas2/service.ts#L35) and [bundleOas3Service](https://github.com/stoplightio/http-spec/blob/master/src/oas3/service.ts#L26)