### PR TITLE
fix: indicate whether the min/max value were provided in the original schema

### DIFF
--- a/src/oas/__tests__/__snapshots__/operation.test.ts.snap
+++ b/src/oas/__tests__/__snapshots__/operation.test.ts.snap
@@ -32,6 +32,12 @@ Array [
                   "maximum": 9223372036854776000,
                   "minimum": -9223372036854776000,
                   "type": "integer",
+                  "x-stoplight": Object {
+                    "explicitProperties": Array [
+                      "type",
+                      "format",
+                    ],
+                  },
                 },
                 "name": Object {
                   "examples": Array [
@@ -87,6 +93,12 @@ Array [
                   "maximum": 9223372036854776000,
                   "minimum": -9223372036854776000,
                   "type": "integer",
+                  "x-stoplight": Object {
+                    "explicitProperties": Array [
+                      "type",
+                      "format",
+                    ],
+                  },
                 },
                 "name": Object {
                   "examples": Array [
@@ -337,6 +349,10 @@ Array [
               "minimum": -9223372036854776000,
               "type": "number",
               "x-stoplight": Object {
+                "explicitProperties": Array [
+                  "type",
+                  "format",
+                ],
                 "id": "schema-http_header-http_response-http_operation-abc-options-/pets-200-X-Rate-Limit-",
               },
             },
@@ -431,6 +447,12 @@ Array [
                   "maximum": 9223372036854776000,
                   "minimum": -9223372036854776000,
                   "type": "integer",
+                  "x-stoplight": Object {
+                    "explicitProperties": Array [
+                      "type",
+                      "format",
+                    ],
+                  },
                 },
                 "name": Object {
                   "examples": Array [
@@ -486,6 +508,12 @@ Array [
                   "maximum": 9223372036854776000,
                   "minimum": -9223372036854776000,
                   "type": "integer",
+                  "x-stoplight": Object {
+                    "explicitProperties": Array [
+                      "type",
+                      "format",
+                    ],
+                  },
                 },
                 "name": Object {
                   "examples": Array [
@@ -710,6 +738,12 @@ Array [
                   "maximum": 9223372036854776000,
                   "minimum": -9223372036854776000,
                   "type": "integer",
+                  "x-stoplight": Object {
+                    "explicitProperties": Array [
+                      "type",
+                      "format",
+                    ],
+                  },
                 },
                 "name": Object {
                   "examples": Array [
@@ -766,6 +800,12 @@ Array [
                   "maximum": 9223372036854776000,
                   "minimum": -9223372036854776000,
                   "type": "integer",
+                  "x-stoplight": Object {
+                    "explicitProperties": Array [
+                      "type",
+                      "format",
+                    ],
+                  },
                 },
                 "name": Object {
                   "examples": Array [
@@ -983,6 +1023,12 @@ Array [
                   "maximum": 9223372036854776000,
                   "minimum": -9223372036854776000,
                   "type": "integer",
+                  "x-stoplight": Object {
+                    "explicitProperties": Array [
+                      "type",
+                      "format",
+                    ],
+                  },
                 },
                 "name": Object {
                   "examples": Array [
@@ -1039,6 +1085,12 @@ Array [
                   "maximum": 9223372036854776000,
                   "minimum": -9223372036854776000,
                   "type": "integer",
+                  "x-stoplight": Object {
+                    "explicitProperties": Array [
+                      "type",
+                      "format",
+                    ],
+                  },
                 },
                 "name": Object {
                   "examples": Array [

--- a/src/oas/transformers/schema/__tests__/schema.spec.ts
+++ b/src/oas/transformers/schema/__tests__/schema.spec.ts
@@ -101,6 +101,9 @@ describe('translateSchemaObject', () => {
             type: 'integer',
             format: 'int64',
             maximum: 2 ** 40,
+            'x-stoplight': {
+              explicitProperties: ['type', 'format', 'maximum'],
+            },
           },
           {
             type: 'integer',
@@ -128,23 +131,35 @@ describe('translateSchemaObject', () => {
           format: 'int64',
           minimum: 0 - 2 ** 63,
           maximum: 2 ** 40,
+          'x-stoplight': {
+            explicitProperties: ['type', 'format', 'maximum'],
+          },
         },
         {
           type: 'integer',
           format: 'int32',
           minimum: 0,
           maximum: 2 ** 31 - 1,
+          'x-stoplight': {
+            explicitProperties: ['type', 'format', 'minimum'],
+          },
         },
         {
           type: 'number',
           format: 'float',
           minimum: 0 - 2 ** 128,
           maximum: 2 ** 128 - 1,
+          'x-stoplight': {
+            explicitProperties: ['type', 'format'],
+          },
         },
         {
           type: 'string',
           format: 'byte',
           pattern: '^[\\w\\d+\\/=]*$',
+          'x-stoplight': {
+            explicitProperties: ['type', 'format'],
+          },
         },
       ],
     });

--- a/src/oas/transformers/schema/keywords/format.ts
+++ b/src/oas/transformers/schema/keywords/format.ts
@@ -15,6 +15,7 @@ const ranges = {
 
 const createNumberFormatter = (min: number, max: number): Converter => {
   return schema => {
+    (schema['x-stoplight'] ??= {}).explicitProperties = Object.keys(schema).filter(word => word !== 'x-stoplight');
     schema.minimum = Math.max(asActualNumber(schema.minimum, min), min);
     schema.maximum = Math.min(asActualNumber(schema.maximum, max), max);
   };
@@ -26,6 +27,7 @@ const convertFormatFloat = createNumberFormatter(ranges.MIN_FLOAT, ranges.MAX_FL
 const convertFormatDouble = createNumberFormatter(ranges.MIN_DOUBLE, ranges.MAX_DOUBLE);
 
 const convertFormatByte: Converter = schema => {
+  (schema['x-stoplight'] ??= {}).explicitProperties = Object.keys(schema).filter(word => word !== 'x-stoplight');
   schema.pattern = '^[\\w\\d+\\/=]*$';
 };
 

--- a/src/oas3/__tests__/operation.test.ts
+++ b/src/oas3/__tests__/operation.test.ts
@@ -712,6 +712,7 @@ describe('transformOas3Operation', () => {
             schema: {
               'x-stoplight': {
                 id: expect.any(String),
+                explicitProperties: expect.any(Array),
               },
               $schema: 'http://json-schema.org/draft-07/schema#',
               type: 'string',
@@ -792,6 +793,7 @@ describe('transformOas3Operation', () => {
             schema: {
               'x-stoplight': {
                 id: expect.any(String),
+                explicitProperties: expect.any(Array),
               },
               $schema: 'http://json-schema.org/draft-07/schema#',
               type: 'string',

--- a/src/oas3/transformers/__tests__/__snapshots__/responses.test.ts.snap
+++ b/src/oas3/transformers/__tests__/__snapshots__/responses.test.ts.snap
@@ -63,6 +63,10 @@ Object {
         "minimum": -2147483648,
         "type": "integer",
         "x-stoplight": Object {
+          "explicitProperties": Array [
+            "type",
+            "format",
+          ],
           "id": Any<String>,
         },
       },
@@ -88,6 +92,10 @@ Object {
         "minimum": -2147483648,
         "type": "integer",
         "x-stoplight": Object {
+          "explicitProperties": Array [
+            "type",
+            "format",
+          ],
           "id": Any<String>,
         },
       },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context
A default value is being provided for minimum and maximum when not found in the original schema. While this is intended behavior, there are times when we want to remove these values from the schema when transforming into different types. 

To help with this, we added an x-stoplight object to track which key/values are set explicitly in the original schema.  

## Description
Created an array of property names to track which values are in the schema prior to making changes. 

## How Has This Been Tested?
Ran existing test to validate that they failed, and then updated to pass.
I used yalc to pull into platform-internal to see that the new key value pair is available for use. 
No new tests were added since this case was covered with existing tests. 


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [ ] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [ ] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
