### PR TITLE
fix(oas): change how exclusiveMin & Max are handled

### DIFF
--- a/src/oas/transformers/schema/__tests__/schema.spec.ts
+++ b/src/oas/transformers/schema/__tests__/schema.spec.ts
@@ -61,6 +61,11 @@ describe('translateSchemaObject', () => {
             exclusiveMinimum: false,
             exclusiveMaximum: false,
           },
+          {
+            type: 'integer',
+            exclusiveMinimum: 2,
+            exclusiveMaximum: 10,
+          },
         ],
       }),
     ).toStrictEqual({
@@ -88,6 +93,11 @@ describe('translateSchemaObject', () => {
           type: 'integer',
           minimum: 2,
           maximum: 10,
+        },
+        {
+          type: 'integer',
+          exclusiveMinimum: 2,
+          exclusiveMaximum: 10,
         },
       ],
     });

--- a/src/oas/transformers/schema/keywords/number.ts
+++ b/src/oas/transformers/schema/keywords/number.ts
@@ -9,7 +9,9 @@ function createRangeConverter(
   return schema => {
     if (!(keyword in schema)) return;
     const { [keyword]: value } = schema;
-    if (value !== true || typeof schema[valueKeyword] !== 'number') {
+    if (typeof value === 'number') {
+      return;
+    } else if (value !== true || typeof schema[valueKeyword] !== 'number') {
       delete schema[keyword];
     } else {
       schema[keyword] = schema[valueKeyword];


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context
As part of supporting OAS 3.1 exporter, I noticed that exclusiveMinimum and exclusiveMaximum values were not being preserved. Since we handle changing this behavior with the drafts, it makes sense to preserve these values during the http spec process

Reminder: 
OAS3 - exclusiveMin / Max are booleans
OAS3.1 - exclusiveMin / Max are integers

#https://github.com/stoplightio/platform-internal/issues/15265

## Description
check to see if value is a number and do not delete from schema if it is


## How Has This Been Tested?
added test to capture exclusiveMin / Max with integer value
yarn test locally
yalc'd into platform internal and confirmed that all exporter tests (oas2, 3, 3.1) are passsing


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [x] I have added error reporting and followed [the error reporting guidelines](???).
- [x] I have added event tracking and followed [the event tracking guidelines](???).
- [x] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [x] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [x] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
