### PR TITLE
fix(oas2): fix http/ws hosts on port 443

### DIFF
--- a/src/oas2/transformers/__tests__/servers.test.ts
+++ b/src/oas2/transformers/__tests__/servers.test.ts
@@ -124,4 +124,32 @@ describe('translateToServers', () => {
       },
     ]);
   });
+
+  it.each([
+    ['http', 80],
+    ['ws', 80],
+    ['https', 443],
+    ['wss', 443],
+  ])('should handle default %s port %s', (scheme, port) => {
+    expect(translateToServers({ host: `stoplight.io:${port}` }, { schemes: [scheme] })).toEqual([
+      {
+        id: expect.any(String),
+        url: `${scheme}://stoplight.io`,
+      },
+    ]);
+  });
+
+  it.each([
+    ['http', 443],
+    ['ws', 443],
+    ['https', 80],
+    ['wss', 80],
+  ])('should handle flip-flopped %s on port %s', (scheme, port) => {
+    expect(translateToServers({ host: `stoplight.io:${port}` }, { schemes: [scheme] })).toEqual([
+      {
+        id: expect.any(String),
+        url: `${scheme}://stoplight.io:${port}`,
+      },
+    ]);
+  });
 });

--- a/src/oas2/transformers/servers.ts
+++ b/src/oas2/transformers/servers.ts
@@ -39,8 +39,8 @@ export const translateToServer = withContext<
     typeof this.document.basePath === 'string' && this.document.basePath.length > 0 ? this.document.basePath : null;
 
   const uri = new URL('https://localhost');
-  uri.host = host;
   uri.protocol = `${scheme}:`;
+  uri.host = host;
 
   if (basePath !== null) {
     uri.pathname = basePath;


### PR DESCRIPTION
when a host specifies 443 and the scheme is http or ws, the port is dropped by the `URL` type. this should make that happen. added tests to cover this scenario