### PR TITLE
fix: 15985 parameter and header with same key should have unique ids

### DIFF
--- a/src/generators.ts
+++ b/src/generators.ts
@@ -55,8 +55,8 @@ export const idGenerators = {
     return join(['http_cookie', props.parentId, props.keyOrName]);
   },
 
-  httpHeader: (props: Context & { keyOrName: string }) => {
-    return join(['http_header', props.parentId, props.keyOrName]);
+  httpHeader: (props: Context & { keyOrName: string; componentType: 'parameter' | 'header' }) => {
+    return join(['http_header', props.parentId, props.componentType, props.keyOrName]);
   },
 
   httpRequestBody: (props: Context & { key?: string; consumes?: string[] }) => {

--- a/src/oas/__tests__/__snapshots__/operation.test.ts.snap
+++ b/src/oas/__tests__/__snapshots__/operation.test.ts.snap
@@ -208,13 +208,13 @@ Array [
       "cookie": Array [],
       "headers": Array [
         Object {
-          "id": "http_header-abc-rate-limit",
+          "id": "http_header-abc-parameter-rate-limit",
           "name": "Rate-Limit",
           "schema": Object {
             "$schema": "http://json-schema.org/draft-07/schema#",
             "type": "string",
             "x-stoplight": Object {
-              "id": "schema-http_header-abc-rate-limit-",
+              "id": "schema-http_header-abc-parameter-rate-limit-",
             },
           },
           "style": "simple",
@@ -283,13 +283,13 @@ Array [
       "cookie": Array [],
       "headers": Array [
         Object {
-          "id": "http_header-abc-rate-limit",
+          "id": "http_header-abc-parameter-rate-limit",
           "name": "Rate-Limit",
           "schema": Object {
             "$schema": "http://json-schema.org/draft-07/schema#",
             "type": "string",
             "x-stoplight": Object {
-              "id": "schema-http_header-abc-rate-limit-",
+              "id": "schema-http_header-abc-parameter-rate-limit-",
             },
           },
           "style": "simple",
@@ -331,20 +331,20 @@ Array [
         "headers": Array [
           Object {
             "description": "Allowed clients",
-            "id": "http_header-http_response-http_operation-abc-options-/pets-200-Allow",
+            "id": "http_header-http_response-http_operation-abc-options-/pets-200-parameter-Allow",
             "name": "Allow",
             "schema": Object {
               "$schema": "http://json-schema.org/draft-07/schema#",
               "type": "string",
               "x-stoplight": Object {
-                "id": "schema-http_header-http_response-http_operation-abc-options-/pets-200-Allow-",
+                "id": "schema-http_header-http_response-http_operation-abc-options-/pets-200-parameter-Allow-",
               },
             },
             "style": "simple",
           },
           Object {
             "description": "Remaining requests",
-            "id": "http_header-http_response-http_operation-abc-options-/pets-200-X-Rate-Limit",
+            "id": "http_header-http_response-http_operation-abc-options-/pets-200-parameter-X-Rate-Limit",
             "name": "X-Rate-Limit",
             "schema": Object {
               "$schema": "http://json-schema.org/draft-07/schema#",
@@ -357,7 +357,7 @@ Array [
                   "type",
                   "format",
                 ],
-                "id": "schema-http_header-http_response-http_operation-abc-options-/pets-200-X-Rate-Limit-",
+                "id": "schema-http_header-http_response-http_operation-abc-options-/pets-200-parameter-X-Rate-Limit-",
               },
             },
             "style": "simple",

--- a/src/oas2/__tests__/__fixtures__/id/bundled.ts
+++ b/src/oas2/__tests__/__fixtures__/id/bundled.ts
@@ -27,7 +27,7 @@ export default {
     header: [
       {
         // hash('http_header-service_abc-Some-Header')
-        id: 'http_header-service_abc-Some-Header',
+        id: 'http_header-service_abc-parameter-Some-Header',
         key: 'Some-Header',
         name: 'A-Shared-Header',
         style: 'simple',
@@ -37,7 +37,7 @@ export default {
           type: 'string',
           'x-stoplight': {
             // hash('schema-http_header-service_abc-Some-Header')
-            id: 'schema-http_header-service_abc-Some-Header-',
+            id: 'schema-http_header-service_abc-parameter-Some-Header-',
           },
         },
       },
@@ -271,12 +271,12 @@ export default {
         cookie: [],
         headers: [
           {
-            id: 'http_header-http_operation-service_abc-post-/users/{}-Post-Specific-Header',
+            id: 'http_header-http_operation-service_abc-post-/users/{}-parameter-Post-Specific-Header',
             name: 'Post-Specific-Header',
             schema: {
               $schema: 'http://json-schema.org/draft-07/schema#',
               'x-stoplight': {
-                id: 'schema-http_header-http_operation-service_abc-post-/users/{}-Post-Specific-Header-',
+                id: 'schema-http_header-http_operation-service_abc-post-/users/{}-parameter-Post-Specific-Header-',
               },
               type: 'integer',
             },

--- a/src/oas2/transformers/__tests__/__snapshots__/params.test.ts.snap
+++ b/src/oas2/transformers/__tests__/__snapshots__/params.test.ts.snap
@@ -83,7 +83,7 @@ exports[`params.translator translateToHeaderParams should translate empty dictio
 exports[`params.translator translateToHeaderParams should translate to multiple header params 1`] = `
 Object {
   "description": "a description",
-  "id": "117996bbb6f45",
+  "id": "4a76be1a8b54a",
   "name": "header-name",
   "schema": Object {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -99,7 +99,7 @@ Object {
 exports[`params.translator translateToHeaderParams should translate to multiple header params 2`] = `
 Object {
   "description": "another description",
-  "id": "dce8b374eb7d6",
+  "id": "d047efbd7d6b5",
   "name": "plain-tex",
   "schema": Object {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -115,7 +115,7 @@ Object {
 exports[`params.translator translateToHeaderParams should translate to simple header param 1`] = `
 Object {
   "description": "a description",
-  "id": "117996bbb6f45",
+  "id": "4a76be1a8b54a",
   "name": "header-name",
   "schema": Object {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/src/oas2/transformers/params.ts
+++ b/src/oas2/transformers/params.ts
@@ -77,7 +77,7 @@ export const translateToHeaderParam = withContext<
   const keyOrName = getSharedKey(param, name);
 
   return {
-    id: this.generateId.httpHeader({ keyOrName }),
+    id: this.generateId.httpHeader({ keyOrName, componentType: 'parameter' }),
     name,
     style: HttpParamStyles.Simple,
     ...buildSchemaForParameter.call(this, param),

--- a/src/oas3/__tests__/__fixtures__/id/bundled.ts
+++ b/src/oas3/__tests__/__fixtures__/id/bundled.ts
@@ -34,7 +34,7 @@ export default {
     header: [
       {
         // hash('http_header-service_abc-Some-Header')
-        id: 'http_header-service_abc-Some-Header',
+        id: 'http_header-service_abc-parameter-Some-Header',
         key: 'Some-Header',
         name: 'A-Shared-Header',
         style: 'simple',
@@ -45,7 +45,7 @@ export default {
           type: 'string',
           'x-stoplight': {
             // hash('schema-http_header-service_abc-Some-Header')
-            id: 'schema-http_header-service_abc-Some-Header-',
+            id: 'schema-http_header-service_abc-parameter-Some-Header-',
           },
         },
       },
@@ -297,13 +297,13 @@ export default {
         headers: [
           {
             examples: [],
-            id: 'http_header-http_operation-service_abc-post-/users/{}-Post-Specific-Header',
+            id: 'http_header-http_operation-service_abc-post-/users/{}-parameter-Post-Specific-Header',
             name: 'Post-Specific-Header',
             schema: {
               $schema: 'http://json-schema.org/draft-07/schema#',
               type: 'integer',
               'x-stoplight': {
-                id: 'schema-http_header-http_operation-service_abc-post-/users/{}-Post-Specific-Header-',
+                id: 'schema-http_header-http_operation-service_abc-post-/users/{}-parameter-Post-Specific-Header-',
               },
             },
             style: 'simple',

--- a/src/oas3/__tests__/__fixtures__/id/legacy.ts
+++ b/src/oas3/__tests__/__fixtures__/id/legacy.ts
@@ -172,14 +172,14 @@ export default [
           // This header was defined in shared components originally, note how this ends up appearing several times in this doc.
           // The closest parent with an id is the service, so ends up being...
           // hash('http_header-service_abc-Some-Header')
-          id: 'http_header-service_abc-Some-Header',
+          id: 'http_header-service_abc-parameter-Some-Header',
           name: 'A-Shared-Header',
           required: false,
           style: 'simple',
           schema: {
             $schema: 'http://json-schema.org/draft-07/schema#',
             'x-stoplight': {
-              id: 'schema-http_header-service_abc-Some-Header-',
+              id: 'schema-http_header-service_abc-parameter-Some-Header-',
             },
             type: 'string',
           },
@@ -393,13 +393,13 @@ export default [
           // This was defined directly on the operation (not a shared component), so the closest
           // parent with an id is the operation, so ends up being...
           // hash('http_header-http_operation-service_abc-post-/users/{}-Post-Specific-Header')
-          id: 'http_header-http_operation-service_abc-post-/users/{}-Post-Specific-Header',
+          id: 'http_header-http_operation-service_abc-post-/users/{}-parameter-Post-Specific-Header',
           name: 'Post-Specific-Header',
           style: 'simple',
           schema: {
             $schema: 'http://json-schema.org/draft-07/schema#',
             'x-stoplight': {
-              id: 'schema-http_header-http_operation-service_abc-post-/users/{}-Post-Specific-Header-',
+              id: 'schema-http_header-http_operation-service_abc-post-/users/{}-parameter-Post-Specific-Header-',
             },
             type: 'integer',
           },
@@ -410,7 +410,7 @@ export default [
           // This header was defined in shared components originally, note how this ends up appearing several times in this doc.
           // The closest parent with an id is the service, so ends up being...
           // hash('http_header-service_abc-Some-Header')
-          id: 'http_header-service_abc-Some-Header',
+          id: 'http_header-service_abc-parameter-Some-Header',
           name: 'A-Shared-Header',
           required: false,
           style: 'simple',
@@ -418,7 +418,7 @@ export default [
             $schema: 'http://json-schema.org/draft-07/schema#',
             'x-stoplight': {
               // hash('schema-http_header-service_abc-Some-Header-')
-              id: 'schema-http_header-service_abc-Some-Header-',
+              id: 'schema-http_header-service_abc-parameter-Some-Header-',
             },
             type: 'string',
           },

--- a/src/oas3/__tests__/__fixtures__/shared-components/bundled.ts
+++ b/src/oas3/__tests__/__fixtures__/shared-components/bundled.ts
@@ -78,7 +78,7 @@ export default {
     ],
     header: [
       {
-        id: 'http_header-service_abc-X-Rate-Limit',
+        id: 'http_header-service_abc-header-X-Rate-Limit',
         key: 'X-Rate-Limit',
         name: 'X-Rate-Limit',
         style: 'simple',
@@ -89,7 +89,7 @@ export default {
         },
       },
       {
-        id: 'http_header-service_abc-Some-Header',
+        id: 'http_header-service_abc-parameter-Some-Header',
         key: 'Some-Header',
         name: 'A-Shared-Header',
         style: 'simple',
@@ -99,7 +99,7 @@ export default {
           $schema: 'http://json-schema.org/draft-07/schema#',
           type: 'string',
           'x-stoplight': {
-            id: 'schema-http_header-service_abc-Some-Header-',
+            id: 'schema-http_header-service_abc-parameter-Some-Header-',
           },
         },
       },

--- a/src/oas3/__tests__/__fixtures__/shared-components/legacy.ts
+++ b/src/oas3/__tests__/__fixtures__/shared-components/legacy.ts
@@ -45,7 +45,7 @@ export default [
             // hash(`http_header-${parentId}-${header key}`)
             // it's a shared header, so the closest parent is the service.
             // hash('http_header-service_abc-X-Rate-Limit')
-            id: 'http_header-service_abc-X-Rate-Limit',
+            id: 'http_header-service_abc-header-X-Rate-Limit',
             name: 'X-Rate-Limit',
             style: 'simple',
             encodings: [],
@@ -109,7 +109,7 @@ export default [
       headers: [
         {
           // hash('http_header-service_abc-Some-Header')
-          id: 'http_header-service_abc-Some-Header',
+          id: 'http_header-service_abc-parameter-Some-Header',
           name: 'A-Shared-Header',
           required: false,
           schema: {
@@ -117,7 +117,7 @@ export default [
             type: 'string',
             'x-stoplight': {
               // hash('schema-http_header-service_abc-Some-Header-')
-              id: 'schema-http_header-service_abc-Some-Header-',
+              id: 'schema-http_header-service_abc-parameter-Some-Header-',
             },
           },
           examples: [],
@@ -181,7 +181,7 @@ export default [
         description: 'Forbidden',
         headers: [
           {
-            id: 'http_header-service_abc-X-Rate-Limit',
+            id: 'http_header-service_abc-header-X-Rate-Limit',
             encodings: [],
             examples: [],
             name: 'X-Rate-Limit',
@@ -258,7 +258,7 @@ export default [
       cookie: [],
       headers: [
         {
-          id: 'http_header-service_abc-Some-Header',
+          id: 'http_header-service_abc-parameter-Some-Header',
           name: 'A-Shared-Header',
           style: 'simple',
           required: false,
@@ -266,7 +266,7 @@ export default [
           schema: {
             $schema: 'http://json-schema.org/draft-07/schema#',
             'x-stoplight': {
-              id: 'schema-http_header-service_abc-Some-Header-',
+              id: 'schema-http_header-service_abc-parameter-Some-Header-',
             },
             type: 'string',
           },

--- a/src/oas3/__tests__/bundle.test.ts
+++ b/src/oas3/__tests__/bundle.test.ts
@@ -119,7 +119,7 @@ describe('bundleOas3Service', () => {
         securitySchemes: [],
         header: [
           {
-            id: 'http_header-service_id-org',
+            id: 'http_header-service_id-parameter-org',
             name: 'org',
             style: 'simple',
             examples: [],
@@ -128,7 +128,7 @@ describe('bundleOas3Service', () => {
               type: 'string',
               $schema: 'http://json-schema.org/draft-07/schema#',
               'x-stoplight': {
-                id: 'schema-http_header-service_id-org-',
+                id: 'schema-http_header-service_id-parameter-org-',
               },
             },
             key: 'org',
@@ -262,7 +262,7 @@ describe('bundleOas3Service', () => {
         header: [
           {
             examples: [],
-            id: 'http_header-undefined-Some-Header',
+            id: 'http_header-undefined-parameter-Some-Header',
             key: 'Some-Header',
             name: 'A-Shared-Header',
             required: false,
@@ -270,7 +270,7 @@ describe('bundleOas3Service', () => {
               $schema: 'http://json-schema.org/draft-07/schema#',
               type: 'string',
               'x-stoplight': {
-                id: 'schema-http_header-undefined-Some-Header-',
+                id: 'schema-http_header-undefined-parameter-Some-Header-',
               },
             },
             style: 'simple',
@@ -905,5 +905,95 @@ describe('bundleOas3Service', () => {
         },
       ],
     });
+  });
+
+  it('should handle parameter and header components with same key', () => {
+    const res = bundleOas3Service({
+      document: {
+        openapi: '3.1.0',
+        servers: [
+          {
+            url: 'https://server.url',
+          },
+        ],
+        info: {
+          license: {
+            name: 'Info license name',
+            url: 'https://lisence.com',
+          },
+          contact: {
+            email: 'info@contact.email',
+            name: 'Info contact name',
+            url: 'https://info.contact/url',
+          },
+          description: 'Info description',
+          title: 'Info title',
+          version: '0.0.1',
+        },
+        tags: [
+          {
+            name: 'tag1',
+            description: 'tag1 description',
+          },
+        ],
+        paths: {
+          '/path1': {
+            get: {
+              operationId: 'getPath1',
+              description: 'getPath1 description',
+              tags: ['tag1'],
+              parameters: [
+                {
+                  $ref: '#/components/parameters/duplicateNamedComponent',
+                },
+              ],
+              responses: {
+                '200': {
+                  description: 'getPath1 200 response description',
+                  headers: {
+                    path1ResponseHeader: {
+                      $ref: '#/components/headers/duplicateNamedComponent',
+                    },
+                  },
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        components: {
+          parameters: {
+            duplicateNamedComponent: {
+              name: 'duplicateNamedComponentParameter',
+              description: 'parameter description',
+              style: 'simple',
+              in: 'header',
+              schema: {
+                type: 'string',
+              },
+            },
+          },
+          headers: {
+            duplicateNamedComponent: {
+              schema: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(res.components.header).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'http_header-undefined-header-duplicateNamedComponent' }),
+        expect.objectContaining({ id: 'http_header-undefined-parameter-duplicateNamedComponent' }),
+      ]),
+    );
   });
 });

--- a/src/oas3/transformers/headers.ts
+++ b/src/oas3/transformers/headers.ts
@@ -27,7 +27,7 @@ export const translateHeaderObject = withContext<
 
   if (!isPlainObject(maybeHeaderObject)) return;
 
-  const id = this.generateId.httpHeader({ keyOrName: name });
+  const id = this.generateId.httpHeader({ keyOrName: name, componentType: 'header' });
 
   if (!isHeaderObject(maybeHeaderObject)) {
     return {

--- a/src/oas3/transformers/request.ts
+++ b/src/oas3/transformers/request.ts
@@ -102,7 +102,7 @@ export const translateParameterObject = withContext<
   const kind = parameterObject.in === 'path' ? 'pathParam' : parameterObject.in;
   const name = parameterObject.name;
   const keyOrName = getSharedKey(parameterObject, name);
-  const id = this.generateId[`http${kind[0].toUpperCase()}${kind.slice(1)}`]({ keyOrName });
+  const id = this.generateId[`http${kind[0].toUpperCase()}${kind.slice(1)}`]({ keyOrName, componentType: 'parameter' });
   const schema = translateParameterObjectSchema.call(this, parameterObject);
 
   const examples = entries(parameterObject.examples).map(translateToExample, this).filter(isNonNullable);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[#15985](https://github.com/stoplightio/platform-internal/issues/15985)

## Description
<!-- Describe your technical changes in detail. -->
- adds new `componentType` prop to http_header id generator
- this distinguishes a header defined in `parameters` and a header defined in `headers` that have the same key and ensures they have unique ids

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Did you test the changes locally, in a PR environment, or somewhere else? -->
<!-- Were unit/integration/e2e/other tests added? If not, why? -->
<!-- Also describe how one or more persons giving a code review can verify your changes. -->
- units tests added and updated
- yalc'd this into platform-internal and it fixes the issues seen in export when a parameter and header have the same key. Also didn't seem to break any of the other analyzer, studio, etc. tests.

## Screenshot(s)/recordings(s)
<!-- If applicable, add screenshots or gifs to help demonstrate the changes. -->
<!-- If not applicable, remove this screenshots section before creating the PR. -->


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [x] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [x] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
