### PR TITLE
fix: 16280 match body and formdata params to their respective consumes

### DIFF
--- a/src/oas2/transformers/__tests__/__snapshots__/request.test.ts.snap
+++ b/src/oas2/transformers/__tests__/__snapshots__/request.test.ts.snap
@@ -26,7 +26,7 @@ Object {
     "contents": Array [
       Object {
         "id": Any<String>,
-        "mediaType": "*",
+        "mediaType": "multipart/form-data",
         "schema": Object {
           "$schema": "http://json-schema.org/draft-07/schema#",
           "properties": Object {

--- a/src/oas2/transformers/__tests__/params.test.ts
+++ b/src/oas2/transformers/__tests__/params.test.ts
@@ -235,6 +235,26 @@ describe('params.translator', () => {
       });
     });
 
+    it('should not map a body param to form data consumes', () => {
+      consumes = ['*', 'application/x-www-form-urlencoded', 'multipart/form-data'];
+
+      const results = translateToBodyParameter(
+        {},
+        {
+          in: 'body',
+          name: 'name',
+          required: true,
+          description: 'descr',
+          schema: {
+            format: 'e-mail',
+          },
+        },
+        consumes,
+      );
+      expect(results.contents?.length).toEqual(1);
+      expect(results.contents![0].mediaType).toEqual('*');
+    });
+
     describe('schema examples', () => {
       describe('given response with schema with x-examples', () => {
         it('should translate to body parameter with examples', () => {
@@ -408,6 +428,20 @@ describe('params.translator', () => {
           Object.assign({}, expectedContent, { mediaType: 'multipart/form-data' }),
         ],
       });
+    });
+
+    it('should not map a form data param to non-form data consumes', () => {
+      consumes = ['application/x-www-form-urlencoded', 'multipart/form-data', '*'];
+
+      const results = translateFromFormDataParameters(
+        {},
+        [formDataParameterString, formDataParameterArray, formDataParameterInteger],
+        consumes,
+      );
+
+      expect(results.contents?.length).toEqual(2);
+      expect(results.contents![0].mediaType).toEqual('application/x-www-form-urlencoded');
+      expect(results.contents![1].mediaType).toEqual('multipart/form-data');
     });
   });
 

--- a/src/oas2/transformers/__tests__/request.test.ts
+++ b/src/oas2/transformers/__tests__/request.test.ts
@@ -9,8 +9,8 @@ import {
 import { createContext } from '../../../oas/context';
 import { translateToRequest as _translateToRequest } from '../request';
 
-const translateToRequest = (parameters: any[]) => {
-  const document = { consumes: ['*'], paths: { '/api': { get: { parameters } } } };
+const translateToRequest = (parameters: any[], consumes?: string[]) => {
+  const document = { consumes: consumes ?? ['*'], paths: { '/api': { get: { parameters } } } };
   const ctx = createContext(document);
   return _translateToRequest.call(ctx, document.paths['/api'], document.paths['/api'].get);
 };
@@ -37,7 +37,7 @@ describe('request', () => {
   });
 
   it('given single form param should translate to request with form', () => {
-    expect(translateToRequest([fakeFormParameter])).toMatchSnapshot({
+    expect(translateToRequest([fakeFormParameter], ['multipart/form-data'])).toMatchSnapshot({
       body: {
         id: expect.any(String),
         contents: [

--- a/src/oas2/transformers/params.ts
+++ b/src/oas2/transformers/params.ts
@@ -47,6 +47,8 @@ type QueryParameterStyle = {
   explode?: boolean;
 };
 
+const FORM_DATA_CONSUMES = ['application/x-www-form-urlencoded', 'multipart/form-data'];
+
 function chooseQueryParameterStyle(parameter: DeepPartial<QueryParameter>): QueryParameterStyle {
   if (parameter.type !== 'array') {
     return { style: HttpParamStyles.Unspecified };
@@ -123,10 +125,12 @@ export const translateToBodyParameter = withContext<
     translateToDefaultExample.call(this, key, value),
   );
 
+  const nonFormDataConsumes = consumes.filter(c => !FORM_DATA_CONSUMES.includes(c));
+
   return {
     id,
 
-    contents: consumes.map(
+    contents: nonFormDataConsumes.map(
       withContext(mediaType => {
         return {
           id: this.generateId.httpMedia({ mediaType }),
@@ -173,10 +177,11 @@ export const translateFromFormDataParameters = withContext<
     IHttpOperationRequestBody
   >
 >(function (parameters, consumes) {
+  const formDataConsumes = consumes.filter(c => FORM_DATA_CONSUMES.includes(c));
   const finalBody: Omit<IHttpOperationRequestBody, 'contents'> & Required<Pick<IHttpOperationRequestBody, 'contents'>> =
     {
-      id: this.generateId.httpRequestBody({ consumes }),
-      contents: consumes.map(
+      id: this.generateId.httpRequestBody({ consumes: formDataConsumes }),
+      contents: formDataConsumes.map(
         withContext(mediaType => ({
           id: this.generateId.httpMedia({ mediaType }),
           mediaType,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[#16280](https://github.com/stoplightio/platform-internal/issues/16280)

## Description
<!-- Describe your technical changes in detail. -->
Make sure body params do not get mapped to form data consumes values and visa versa

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Did you test the changes locally, in a PR environment, or somewhere else? -->
<!-- Were unit/integration/e2e/other tests added? If not, why? -->
<!-- Also describe how one or more persons giving a code review can verify your changes. -->
- unit tests

## Screenshot(s)/recordings(s)
<!-- If applicable, add screenshots or gifs to help demonstrate the changes. -->
<!-- If not applicable, remove this screenshots section before creating the PR. -->


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [ ] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [ ] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
