### PR TITLE
fix(oas2): include shared responses in bundled service

### DIFF
--- a/src/oas2/__tests__/__fixtures__/id/bundled.ts
+++ b/src/oas2/__tests__/__fixtures__/id/bundled.ts
@@ -45,7 +45,16 @@ export default {
     path: [],
     query: [],
     requestBodies: [],
-    responses: [],
+    responses: [
+      {
+        id: 'http_response-service_abc-ErrorResponse',
+        key: 'ErrorResponse',
+        code: 'ErrorResponse',
+        contents: [],
+        description: 'A generic error response.',
+        headers: [],
+      },
+    ],
     schemas: [
       {
         $schema: 'http://json-schema.org/draft-07/schema#',

--- a/src/oas2/service.ts
+++ b/src/oas2/service.ts
@@ -11,6 +11,7 @@ import { transformOasService } from '../oas/service';
 import { translateToComponents } from '../oas/transformers/components';
 import { translateSchemaObjectFromPair } from '../oas/transformers/schema';
 import { Oas2HttpServiceBundle, Oas2HttpServiceTransformer, OasVersion } from '../oas/types';
+import { translateToResponse } from '../oas3/transformers/responses';
 import { ArrayCallbackParameters, RefResolver } from '../types';
 import { entries } from '../utils';
 import { transformOas2Operations } from './operation';
@@ -41,6 +42,7 @@ export const bundleOas2Service: Oas2HttpServiceBundle = ({ document: _document }
     ...translateToComponents.call(ctx, OasVersion.OAS2, {
       definitions: translateSchemaObjectFromPair,
       securityDefinitions: translateSecurityScheme,
+      responses: translateToResponse,
     }),
     ...translateToSharedParameters.call(ctx, document),
   };


### PR DESCRIPTION
Even though they aren't used directly in the bundle itself (due to our handling of consumes/produces), we should include them so that SL Doc can correctly link cross-file references.