### PR TITLE
fix(oas): do not drop operation responses if they have eternal ref

### DIFF
--- a/src/oas3/transformers/responses.ts
+++ b/src/oas3/transformers/responses.ts
@@ -18,7 +18,7 @@ export const translateToResponse = withContext<
     Optional<IHttpOperationResponse<true> | (Pick<IHttpOperationResponse, 'code'> & Reference)>
   >
 >(function ([statusCode, response]) {
-  const maybeResponseObject = this.maybeResolveLocalRef(response);
+  const maybeResponseObject = this.maybeResolveLocalRef(response) ?? response;
 
   if (isReferenceObject(maybeResponseObject)) {
     (maybeResponseObject as Pick<IHttpOperationResponse, 'code'> & Reference).code = statusCode;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[#17558](https://github.com/stoplightio/platform-internal/issues/17558)

## Description
<!-- Describe your technical changes in detail. -->
- do not drop operation responses if they have an external ref along their chain of refs

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Did you test the changes locally, in a PR environment, or somewhere else? -->
<!-- Were unit/integration/e2e/other tests added? If not, why? -->
<!-- Also describe how one or more persons giving a code review can verify your changes. -->
- unit test
- yalc'd into platform-internal and tested with refs.spec.ts

## Screenshot(s)/recordings(s)
<!-- If applicable, add screenshots or gifs to help demonstrate the changes. -->
<!-- If not applicable, remove this screenshots section before creating the PR. -->


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [x] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [x] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
