### PR TITLE
Fix int64 overflow issue to due precision issues in Typescript with large numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "lodash.pickby": "^4.6.0",
     "openapi3-ts": "^2.0.2",
     "postman-collection": "^4.1.2",
-    "tslib": "^2.3.1",
+    "tslib": "^2.6.2",
     "type-is": "^1.6.18"
   },
   "devDependencies": {

--- a/src/oas/__tests__/__snapshots__/operation.test.ts.snap
+++ b/src/oas/__tests__/__snapshots__/operation.test.ts.snap
@@ -29,8 +29,8 @@ Array [
                 },
                 "id": Object {
                   "format": "int64",
-                  "maximum": 9223372036854776000,
-                  "minimum": -9223372036854776000,
+                  "maximum": 9007199254740991,
+                  "minimum": -9007199254740991,
                   "type": "integer",
                   "x-stoplight": Object {
                     "explicitProperties": Array [
@@ -90,8 +90,8 @@ Array [
                 },
                 "id": Object {
                   "format": "int64",
-                  "maximum": 9223372036854776000,
-                  "minimum": -9223372036854776000,
+                  "maximum": 9007199254740991,
+                  "minimum": -9007199254740991,
                   "type": "integer",
                   "x-stoplight": Object {
                     "explicitProperties": Array [
@@ -349,8 +349,8 @@ Array [
             "schema": Object {
               "$schema": "http://json-schema.org/draft-07/schema#",
               "format": "int64",
-              "maximum": 9223372036854776000,
-              "minimum": -9223372036854776000,
+              "maximum": 9007199254740991,
+              "minimum": -9007199254740991,
               "type": "number",
               "x-stoplight": Object {
                 "explicitProperties": Array [
@@ -450,8 +450,8 @@ Array [
                 },
                 "id": Object {
                   "format": "int64",
-                  "maximum": 9223372036854776000,
-                  "minimum": -9223372036854776000,
+                  "maximum": 9007199254740991,
+                  "minimum": -9007199254740991,
                   "type": "integer",
                   "x-stoplight": Object {
                     "explicitProperties": Array [
@@ -511,8 +511,8 @@ Array [
                 },
                 "id": Object {
                   "format": "int64",
-                  "maximum": 9223372036854776000,
-                  "minimum": -9223372036854776000,
+                  "maximum": 9007199254740991,
+                  "minimum": -9007199254740991,
                   "type": "integer",
                   "x-stoplight": Object {
                     "explicitProperties": Array [
@@ -744,8 +744,8 @@ Array [
                 },
                 "id": Object {
                   "format": "int64",
-                  "maximum": 9223372036854776000,
-                  "minimum": -9223372036854776000,
+                  "maximum": 9007199254740991,
+                  "minimum": -9007199254740991,
                   "type": "integer",
                   "x-stoplight": Object {
                     "explicitProperties": Array [
@@ -806,8 +806,8 @@ Array [
                 },
                 "id": Object {
                   "format": "int64",
-                  "maximum": 9223372036854776000,
-                  "minimum": -9223372036854776000,
+                  "maximum": 9007199254740991,
+                  "minimum": -9007199254740991,
                   "type": "integer",
                   "x-stoplight": Object {
                     "explicitProperties": Array [
@@ -1042,8 +1042,8 @@ Array [
                 },
                 "id": Object {
                   "format": "int64",
-                  "maximum": 9223372036854776000,
-                  "minimum": -9223372036854776000,
+                  "maximum": 9007199254740991,
+                  "minimum": -9007199254740991,
                   "type": "integer",
                   "x-stoplight": Object {
                     "explicitProperties": Array [
@@ -1104,8 +1104,8 @@ Array [
                 },
                 "id": Object {
                   "format": "int64",
-                  "maximum": 9223372036854776000,
-                  "minimum": -9223372036854776000,
+                  "maximum": 9007199254740991,
+                  "minimum": -9007199254740991,
                   "type": "integer",
                   "x-stoplight": Object {
                     "explicitProperties": Array [

--- a/src/oas/transformers/schema/__tests__/schema.spec.ts
+++ b/src/oas/transformers/schema/__tests__/schema.spec.ts
@@ -110,7 +110,7 @@ describe('translateSchemaObject', () => {
           {
             type: 'integer',
             format: 'int64',
-            maximum: 2 ** 40,
+            maximum: Number.MAX_SAFE_INTEGER,
             'x-stoplight': {
               explicitProperties: ['type', 'format', 'maximum'],
             },
@@ -139,8 +139,8 @@ describe('translateSchemaObject', () => {
         {
           type: 'integer',
           format: 'int64',
-          minimum: 0 - 2 ** 63,
-          maximum: 2 ** 40,
+          minimum: Number.MIN_SAFE_INTEGER,
+          maximum: Number.MAX_SAFE_INTEGER,
           'x-stoplight': {
             explicitProperties: ['type', 'format', 'maximum'],
           },

--- a/src/oas/transformers/schema/keywords/format.ts
+++ b/src/oas/transformers/schema/keywords/format.ts
@@ -6,8 +6,8 @@ import type { Converter } from '../types';
 const ranges = {
   MIN_INT_32: 0 - 2 ** 31,
   MAX_INT_32: 2 ** 31 - 1,
-  MIN_INT_64: 0 - 2 ** 63,
-  MAX_INT_64: 2 ** 63 - 1,
+  MIN_INT_64: Number.MIN_SAFE_INTEGER,
+  MAX_INT_64: Number.MAX_SAFE_INTEGER,
   MIN_FLOAT: 0 - 2 ** 128,
   MAX_FLOAT: 2 ** 128 - 1,
   MIN_DOUBLE: 0 - Number.MAX_VALUE,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10373,6 +10373,11 @@ tslib@^2.0.0, tslib@^2.2.0, tslib@^2.3.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
+tslib@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+
 tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"


### PR DESCRIPTION
Currently, `MAX_INT_64` is set to `2 ** 63 - 1`, and `MIN_INT_64` is set to `0 - 2 ** 63` in `src/oas/transformers/schema/keywords/format.ts`. The TypeScript compiler evaluates these, respectively, to 9223372036854776000 and -9223372036854776000. 

## Motivation and Context
These values are outside the range of int64 and result in bugs in clients such as Prism that use this library (e.g. https://github.com/stoplightio/prism/issues/1992). 

The reasoning behind this erroneous calculation is explained here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER. Essentially, we are overflowing the capacity of JavaScript's Number type, and beyond Number.MAX_SAFE_INTEGER + 1 (9007199254740992), the IEEE-754 floating-point format can no longer represent every consecutive integer (see: https://stackoverflow.com/questions/1379934/large-numbers-erroneously-rounded-in-javascript). 

## Description
Thus, instead of setting `MAX_INT_64` to `2 ** 63 - 1`, and `MIN_INT_64` to `0 - 2 ** 63`, we set them to TypeScript's built-in Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER instead. 

## How Has This Been Tested?
Update local tests including screenshot tests.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [X] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [X] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
