### PR TITLE
feat(oas3): adds webhook support for oas 3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "dependencies": {
     "@stoplight/json": "^3.18.1",
     "@stoplight/json-schema-generator": "1.0.2",
-    "@stoplight/types": "14.0.0",
+    "@stoplight/types": "14.1.0",
     "@types/json-schema": "7.0.11",
     "@types/swagger-schema-official": "~2.0.22",
     "@types/type-is": "^1.6.3",

--- a/src/context.ts
+++ b/src/context.ts
@@ -66,6 +66,8 @@ export function createContext<T extends Record<string, unknown>>(
       service: '',
       path: '',
       operation: '',
+      webhookName: '',
+      webhook: '',
     },
     references: {},
     parentId: '',

--- a/src/generators.ts
+++ b/src/generators.ts
@@ -36,8 +36,16 @@ export const idGenerators = {
     return join(['http_path', props.parentId, sanitizePath(props.path)]);
   },
 
+  httpWebhookName: (props: Context & { name: string }) => {
+    return join(['http_webhook_name', props.parentId, sanitizePath(props.name)]);
+  },
+
   httpOperation: (props: Context & { method: string; path: string }) => {
     return join(['http_operation', props.parentId, props.method, sanitizePath(props.path)]);
+  },
+
+  httpWebhook: (props: Context & { method: string; name: string }) => {
+    return join(['http_webhook', props.parentId, props.method, sanitizePath(props.name)]);
   },
 
   httpCallbackOperation: (props: Context & { method: string; path: string }) => {

--- a/src/generators.ts
+++ b/src/generators.ts
@@ -44,8 +44,8 @@ export const idGenerators = {
     return join(['http_operation', props.parentId, props.method, sanitizePath(props.path)]);
   },
 
-  httpWebhook: (props: Context & { method: string; name: string }) => {
-    return join(['http_webhook', props.parentId, props.method, sanitizePath(props.name)]);
+  httpWebhookOperation: (props: Context & { method: string; name: string }) => {
+    return join(['http_webhook_operation', props.parentId, props.method, sanitizePath(props.name)]);
   },
 
   httpCallbackOperation: (props: Context & { method: string; path: string }) => {

--- a/src/oas/__tests__/operation.test.ts
+++ b/src/oas/__tests__/operation.test.ts
@@ -1,10 +1,10 @@
 import { bundleTarget } from '@stoplight/json';
-import { OpenAPIObject } from 'openapi3-ts';
 import { Spec } from 'swagger-schema-official';
 
 import { setSkipHashing } from '../../hash';
 import { transformOas2Operations } from '../../oas2/operation';
 import { transformOas3Operations } from '../../oas3/operation';
+import { OpenAPIObject } from '../../oas3/types';
 
 setSkipHashing(true);
 

--- a/src/oas/index.ts
+++ b/src/oas/index.ts
@@ -7,7 +7,7 @@ export type {
   Oas2HttpServiceTransformer,
   Oas2TransformOperationOpts,
   Oas2TransformServiceOpts,
-  Oas3HttpOperationTransformer,
+  Oas3HttpEndpointOperationTransformer,
   Oas3HttpServiceBundle,
   Oas3HttpServiceTransformer,
   Oas3TransformOperationOpts,

--- a/src/oas/operation.ts
+++ b/src/oas/operation.ts
@@ -94,7 +94,8 @@ export const transformOasEndpointOperation: TranslateFunction<
     id = this.ids.operation =
       extractId(obj) ?? this.generateId.httpOperation({ parentId: serviceId, method, path: name });
   } else {
-    id = this.ids.webhook = extractId(obj) ?? this.generateId.httpWebhook({ parentId: serviceId, method, name });
+    id = this.ids.webhook =
+      extractId(obj) ?? this.generateId.httpWebhookOperation({ parentId: serviceId, method, name });
   }
 
   this.parentId = id;

--- a/src/oas/service.ts
+++ b/src/oas/service.ts
@@ -1,7 +1,8 @@
 import { isPlainObject } from '@stoplight/json';
 import { DeepPartial, IHttpService } from '@stoplight/types';
-import { OpenAPIObject } from 'openapi3-ts';
 import { Spec } from 'swagger-schema-official';
+
+import { OpenAPIObject } from '../oas3/types';
 import pickBy = require('lodash.pickby');
 
 import { isBoolean, isNonNullable, isString } from '../guards';

--- a/src/oas/types.ts
+++ b/src/oas/types.ts
@@ -1,4 +1,4 @@
-import { DeepPartial, IHttpOperation } from '@stoplight/types';
+import { DeepPartial, IHttpEndpointOperation, IHttpOperation } from '@stoplight/types';
 import type * as OAS3 from 'openapi3-ts';
 import type * as OAS2 from 'swagger-schema-official';
 
@@ -33,7 +33,8 @@ export type Oas3HttpServiceBundle = HttpServiceBundle<Oas3TransformServiceOpts>;
 export type Oas2TransformOperationOpts = ITransformEndpointOperationOpts<DeepPartial<OAS2.Spec>>;
 export type Oas3TransformOperationOpts = ITransformEndpointOperationOpts<DeepPartial<OAS3.OpenAPIObject>>;
 export type Oas2HttpOperationTransformer = HttpEndpointOperationTransformer<Oas2TransformOperationOpts, IHttpOperation>;
-export type Oas3HttpOperationTransformer = HttpEndpointOperationTransformer<Oas3TransformOperationOpts, IHttpOperation>;
+export type Oas3HttpEndpointOperationTransformer<T extends IHttpEndpointOperation = IHttpEndpointOperation> =
+  HttpEndpointOperationTransformer<Oas3TransformOperationOpts, T>;
 
 export type Oas3ParamBase = ParamBase & { in: OAS3.ParameterLocation };
 export type Oas2ParamBase = ParamBase & { in: OAS2.BaseParameter['in'] };

--- a/src/oas/types.ts
+++ b/src/oas/types.ts
@@ -1,12 +1,12 @@
-import { DeepPartial } from '@stoplight/types';
+import { DeepPartial, IHttpOperation } from '@stoplight/types';
 import type * as OAS3 from 'openapi3-ts';
 import type * as OAS2 from 'swagger-schema-official';
 
 import type {
-  HttpOperationTransformer,
+  HttpEndpointOperationTransformer,
   HttpServiceBundle,
   HttpServiceTransformer,
-  ITransformOperationOpts,
+  ITransformEndpointOperationOpts,
   ITransformServiceOpts,
 } from '../types';
 
@@ -30,10 +30,10 @@ export type Oas3HttpServiceBundle = HttpServiceBundle<Oas3TransformServiceOpts>;
 /**
  * Operation
  */
-export type Oas2TransformOperationOpts = ITransformOperationOpts<DeepPartial<OAS2.Spec>>;
-export type Oas3TransformOperationOpts = ITransformOperationOpts<DeepPartial<OAS3.OpenAPIObject>>;
-export type Oas2HttpOperationTransformer = HttpOperationTransformer<Oas2TransformOperationOpts>;
-export type Oas3HttpOperationTransformer = HttpOperationTransformer<Oas3TransformOperationOpts>;
+export type Oas2TransformOperationOpts = ITransformEndpointOperationOpts<DeepPartial<OAS2.Spec>>;
+export type Oas3TransformOperationOpts = ITransformEndpointOperationOpts<DeepPartial<OAS3.OpenAPIObject>>;
+export type Oas2HttpOperationTransformer = HttpEndpointOperationTransformer<Oas2TransformOperationOpts, IHttpOperation>;
+export type Oas3HttpOperationTransformer = HttpEndpointOperationTransformer<Oas3TransformOperationOpts, IHttpOperation>;
 
 export type Oas3ParamBase = ParamBase & { in: OAS3.ParameterLocation };
 export type Oas2ParamBase = ParamBase & { in: OAS2.BaseParameter['in'] };

--- a/src/oas2/__tests__/__fixtures__/id/bundled.ts
+++ b/src/oas2/__tests__/__fixtures__/id/bundled.ts
@@ -426,4 +426,5 @@ export default {
       ],
     },
   ],
+  webhooks: [],
 };

--- a/src/oas2/__tests__/bundle.test.ts
+++ b/src/oas2/__tests__/bundle.test.ts
@@ -159,6 +159,7 @@ describe('bundleOas2Service', () => {
           tags: [],
         },
       ],
+      webhooks: [],
       components: {
         callbacks: [],
         cookie: [],
@@ -281,6 +282,7 @@ describe('bundleOas2Service', () => {
           tags: [],
         },
       ],
+      webhooks: [],
       components: {
         callbacks: [],
         cookie: [],

--- a/src/oas2/__tests__/operation.test.ts
+++ b/src/oas2/__tests__/operation.test.ts
@@ -1,5 +1,4 @@
 import { DeepPartial } from '@stoplight/types';
-import { OpenAPIObject } from 'openapi3-ts';
 import { Spec } from 'swagger-schema-official';
 
 import { setSkipHashing } from '../../hash';
@@ -226,7 +225,7 @@ describe('transformOas2Operation', () => {
   });
 
   it('given malformed parameters should translate operation with those parameters', () => {
-    const document: Partial<OpenAPIObject> = {
+    const document: Partial<DeepPartial<Spec>> = {
       swagger: '2.0',
       paths: {
         '/users/{userId}': {
@@ -236,7 +235,7 @@ describe('transformOas2Operation', () => {
                 in: 'header',
                 name: 'name',
               },
-              null,
+              null as any,
             ],
           },
         },

--- a/src/oas2/__tests__/operation.test.ts
+++ b/src/oas2/__tests__/operation.test.ts
@@ -229,7 +229,7 @@ describe('transformOas2Operation', () => {
   });
 
   it('given malformed parameters should translate operation with those parameters', () => {
-    const document: Partial<DeepPartial<Spec>> = {
+    const document: DeepPartial<Spec> = {
       swagger: '2.0',
       paths: {
         '/users/{userId}': {

--- a/src/oas2/__tests__/operation.test.ts
+++ b/src/oas2/__tests__/operation.test.ts
@@ -2,6 +2,7 @@ import { DeepPartial } from '@stoplight/types';
 import { Spec } from 'swagger-schema-official';
 
 import { setSkipHashing } from '../../hash';
+import { OPERATION_CONFIG } from '../../oas/operation';
 import { transformOas2Operation, transformOas2Operations } from '../operation';
 
 setSkipHashing(true);
@@ -68,9 +69,10 @@ describe('transformOas2Operation', () => {
 
     expect(
       transformOas2Operation({
-        path: '/users/{userId}',
+        name: '/users/{userId}',
         method: 'get',
         document,
+        config: OPERATION_CONFIG,
       }),
     ).toMatchSnapshot({
       id: expect.any(String),
@@ -146,9 +148,10 @@ describe('transformOas2Operation', () => {
     };
 
     const result = transformOas2Operation({
-      path: '/users/{userId}',
+      name: '/users/{userId}',
       method: 'delete',
       document,
+      config: OPERATION_CONFIG,
     });
 
     expect(result.responses[0].contents).toHaveLength(0);
@@ -168,9 +171,10 @@ describe('transformOas2Operation', () => {
 
     expect(
       transformOas2Operation({
-        path: '/users/{userId}',
+        name: '/users/{userId}',
         method: 'get',
         document,
+        config: OPERATION_CONFIG,
       }),
     ).toHaveProperty('deprecated', true);
   });
@@ -244,9 +248,10 @@ describe('transformOas2Operation', () => {
 
     expect(
       transformOas2Operation({
-        path: '/users/{userId}',
+        name: '/users/{userId}',
         method: 'get',
         document,
+        config: OPERATION_CONFIG,
       }),
     ).toStrictEqual({
       id: expect.any(String),

--- a/src/oas2/service.ts
+++ b/src/oas2/service.ts
@@ -53,6 +53,7 @@ export const bundleOas2Service: Oas2HttpServiceBundle = ({ document: _document }
   return {
     ...service,
     operations,
+    webhooks: [],
     components,
   };
 };

--- a/src/oas3/__tests__/__fixtures__/examples/bundled.ts
+++ b/src/oas3/__tests__/__fixtures__/examples/bundled.ts
@@ -66,6 +66,7 @@ export default {
       tags: [],
     },
   ],
+  webhooks: [],
   components: {
     callbacks: [],
     cookie: [],

--- a/src/oas3/__tests__/__fixtures__/id/bundled.ts
+++ b/src/oas3/__tests__/__fixtures__/id/bundled.ts
@@ -391,6 +391,7 @@ export default {
       ],
     },
   ],
+  webhooks: [],
   extensions: {
     'x-stoplight': {
       id: 'service_abc',

--- a/src/oas3/__tests__/__fixtures__/id/bundled.ts
+++ b/src/oas3/__tests__/__fixtures__/id/bundled.ts
@@ -391,7 +391,50 @@ export default {
       ],
     },
   ],
-  webhooks: [],
+  webhooks: [
+    {
+      extensions: {},
+      id: 'http_webhook_operation-service_abc-post-git.push',
+      iid: 'post-git.push',
+      method: 'post',
+      name: 'git.push',
+      request: {
+        body: {
+          contents: [
+            {
+              encodings: [],
+              examples: [],
+              id: 'http_media-http_request_body-http_webhook_operation-service_abc-post-git.push-application/json',
+              mediaType: 'application/json',
+              schema: {
+                $schema: 'http://json-schema.org/draft-07/schema#',
+                type: 'object',
+                'x-stoplight': {
+                  id: 'schema-http_media-http_request_body-http_webhook_operation-service_abc-post-git.push-application/json-',
+                },
+              },
+            },
+          ],
+          id: 'http_request_body-http_webhook_operation-service_abc-post-git.push',
+        },
+        cookie: [],
+        headers: [],
+        path: [],
+        query: [],
+      },
+      responses: [],
+      security: [],
+      securityDeclarationType: 'inheritedFromService',
+      servers: [
+        {
+          id: 'http_server-service_abc-http://localhost:3000',
+          name: 'Users API',
+          url: 'http://localhost:3000',
+        },
+      ],
+      tags: [],
+    },
+  ],
   extensions: {
     'x-stoplight': {
       id: 'service_abc',

--- a/src/oas3/__tests__/__fixtures__/id/input.json
+++ b/src/oas3/__tests__/__fixtures__/id/input.json
@@ -118,6 +118,22 @@
       }
     }
   },
+  "webhooks": {
+    "git.push": {
+      "post": {
+        "operationId": "post-git.push",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
   "components": {
     "schemas": {
       "User": {

--- a/src/oas3/__tests__/__fixtures__/shared-components/bundled.ts
+++ b/src/oas3/__tests__/__fixtures__/shared-components/bundled.ts
@@ -62,6 +62,7 @@ export default {
       tags: [],
     },
   ],
+  webhooks: [],
   components: {
     callbacks: [],
     cookie: [],

--- a/src/oas3/__tests__/accessors.test.ts
+++ b/src/oas3/__tests__/accessors.test.ts
@@ -1,8 +1,8 @@
 import { DeepPartial } from '@stoplight/types';
-import { OpenAPIObject } from 'openapi3-ts';
 
 import { setSkipHashing } from '../../hash';
 import { getSecurities as _getSecurities, OperationSecurities } from '../accessors';
+import { OpenAPIObject } from '../types';
 
 setSkipHashing(true);
 

--- a/src/oas3/__tests__/bundle.test.ts
+++ b/src/oas3/__tests__/bundle.test.ts
@@ -113,6 +113,7 @@ describe('bundleOas3Service', () => {
           servers: [],
         },
       ],
+      webhooks: [],
       components: {
         callbacks: [],
         responses: [],
@@ -401,6 +402,7 @@ describe('bundleOas3Service', () => {
       id: 'undefined',
       name: 'no-title',
       operations: [],
+      webhooks: [],
       version: '',
       extensions: {},
       infoExtensions: {},
@@ -462,6 +464,7 @@ describe('bundleOas3Service', () => {
       id: 'undefined',
       name: 'no-title',
       operations: [],
+      webhooks: [],
       version: '',
       extensions: {},
       infoExtensions: {},
@@ -707,6 +710,7 @@ describe('bundleOas3Service', () => {
           tags: [],
         },
       ],
+      webhooks: [],
     });
   });
 
@@ -770,6 +774,7 @@ describe('bundleOas3Service', () => {
           tags: [],
         },
       ],
+      webhooks: [],
     });
   });
 
@@ -878,6 +883,7 @@ describe('bundleOas3Service', () => {
           tags: [],
         },
       ],
+      webhooks: [],
       components: {
         callbacks: [],
         cookie: [],

--- a/src/oas3/__tests__/operation.test.ts
+++ b/src/oas3/__tests__/operation.test.ts
@@ -1,4 +1,5 @@
 import { setSkipHashing } from '../../hash';
+import { OPERATION_CONFIG } from '../../oas/operation';
 import {
   transformOas3Operation as _transformOas3Operation,
   transformOas3Operations as _transformOas3Operations,
@@ -31,8 +32,9 @@ describe('transformOas3Operation', () => {
 
     expect(
       transformOas3Operation({
-        path: '/users/{userId}',
+        name: '/users/{userId}',
         method: 'get',
+        config: OPERATION_CONFIG,
         document,
       }),
     ).toHaveProperty('deprecated', true);
@@ -61,7 +63,8 @@ describe('transformOas3Operation', () => {
     };
 
     const result = transformOas3Operation({
-      path: '/users/{userId}',
+      name: '/users/{userId}',
+      config: OPERATION_CONFIG,
       method: 'delete',
       document,
     });
@@ -142,7 +145,8 @@ describe('transformOas3Operation', () => {
 
     expect(
       transformOas3Operation({
-        path: '/users/{userId}',
+        name: '/users/{userId}',
+        config: OPERATION_CONFIG,
         method: 'get',
         document,
       }),
@@ -180,7 +184,8 @@ describe('transformOas3Operation', () => {
 
     expect(
       transformOas3Operation({
-        path: '/users/{userId}',
+        name: '/users/{userId}',
+        config: OPERATION_CONFIG,
         method: 'get',
         document,
       }),
@@ -217,7 +222,8 @@ describe('transformOas3Operation', () => {
 
     expect(
       transformOas3Operation({
-        path: '/users/{userId}',
+        name: '/users/{userId}',
+        config: OPERATION_CONFIG,
         method: 'get',
         document,
       }),
@@ -247,7 +253,8 @@ describe('transformOas3Operation', () => {
 
     expect(
       transformOas3Operation({
-        path: '/users/{userId}',
+        name: '/users/{userId}',
+        config: OPERATION_CONFIG,
         method: 'get',
         document,
       }),
@@ -290,7 +297,8 @@ describe('transformOas3Operation', () => {
 
     expect(
       transformOas3Operation({
-        path: '/users/{userId}',
+        name: '/users/{userId}',
+        config: OPERATION_CONFIG,
         method: 'get',
         document,
       }),
@@ -329,8 +337,9 @@ describe('transformOas3Operation', () => {
 
       expect(
         transformOas3Operation({
-          path: '/users/{userId}',
+          name: '/users/{userId}',
           method: 'get',
+          config: OPERATION_CONFIG,
           document,
         }),
       ).toHaveProperty('servers', []);
@@ -360,8 +369,9 @@ describe('transformOas3Operation', () => {
 
     expect(
       transformOas3Operation({
-        path: '/users/{userId}',
+        name: '/users/{userId}',
         method: 'get',
+        config: OPERATION_CONFIG,
         document,
       }),
     ).toHaveProperty('servers', [
@@ -396,8 +406,9 @@ describe('transformOas3Operation', () => {
 
     expect(
       transformOas3Operation({
-        path: '/users/{userId}',
+        name: '/users/{userId}',
         method: 'get',
+        config: OPERATION_CONFIG,
         document,
       }),
     ).toMatchSnapshot({
@@ -435,8 +446,9 @@ describe('transformOas3Operation', () => {
 
       expect(
         transformOas3Operation({
-          path: '/users/{userId}',
+          name: '/users/{userId}',
           method: 'get',
+          config: OPERATION_CONFIG,
           document,
         }),
       ).toHaveProperty('servers', []);
@@ -466,8 +478,9 @@ describe('transformOas3Operation', () => {
 
     expect(
       transformOas3Operation({
-        path: '/users/{userId}',
+        name: '/users/{userId}',
         method: 'get',
+        config: OPERATION_CONFIG,
         document,
       }),
     ).toHaveProperty('servers', [
@@ -502,8 +515,9 @@ describe('transformOas3Operation', () => {
 
     expect(
       transformOas3Operation({
-        path: '/users/{userId}',
+        name: '/users/{userId}',
         method: 'get',
+        config: OPERATION_CONFIG,
         document,
       }),
     ).toMatchSnapshot({
@@ -541,8 +555,9 @@ describe('transformOas3Operation', () => {
 
       expect(
         transformOas3Operation({
-          path: '/users/{userId}',
+          name: '/users/{userId}',
           method: 'get',
+          config: OPERATION_CONFIG,
           document,
         }),
       ).toHaveProperty('servers', []);
@@ -572,8 +587,9 @@ describe('transformOas3Operation', () => {
 
     expect(
       transformOas3Operation({
-        path: '/users/{userId}',
+        name: '/users/{userId}',
         method: 'get',
+        config: OPERATION_CONFIG,
         document,
       }),
     ).toHaveProperty('servers', [
@@ -628,8 +644,9 @@ describe('transformOas3Operation', () => {
 
     expect(
       transformOas3Operation({
-        path: '/subscribe',
+        name: '/subscribe',
         method: 'post',
+        config: OPERATION_CONFIG,
         document,
       }),
     ).toMatchSnapshot({
@@ -686,8 +703,9 @@ describe('transformOas3Operation', () => {
 
     expect(
       transformOas3Operation({
-        path: '/users/{userId}',
+        name: '/users/{userId}',
         method: 'get',
+        config: OPERATION_CONFIG,
         document,
       }),
     ).toStrictEqual({
@@ -769,8 +787,9 @@ describe('transformOas3Operation', () => {
 
     expect(
       transformOas3Operation({
-        path: '/users/{userId}',
+        name: '/users/{userId}',
         method: 'get',
+        config: OPERATION_CONFIG,
         document,
       }),
     ).toStrictEqual({
@@ -857,7 +876,9 @@ describe('transformOas3Operation', () => {
       ],
     };
 
-    expect(transformOas3Operation({ document, path: '/pets', method: 'get' }).servers).toEqual([
+    expect(
+      transformOas3Operation({ document, name: '/pets', method: 'get', config: OPERATION_CONFIG }).servers,
+    ).toEqual([
       {
         id: expect.any(String),
         description: 'Sample Petstore Server Https',
@@ -959,8 +980,9 @@ describe('transformOas3Operation', () => {
 
     expect(
       transformOas3Operation({
-        path: '/pet',
+        name: '/pet',
         method: 'get',
+        config: OPERATION_CONFIG,
         document,
       }),
     ).toStrictEqual({
@@ -1101,8 +1123,9 @@ describe('transformOas3Operation', () => {
 
     expect(
       transformOas3Operation({
-        path: '/pets',
+        name: '/pets',
         method: 'post',
+        config: OPERATION_CONFIG,
         document,
       }),
     ).toHaveProperty('request.body', {
@@ -1168,8 +1191,9 @@ describe('transformOas3Operation', () => {
 
     expect(
       transformOas3Operation({
-        path: '/pets',
+        name: '/pets',
         method: 'post',
+        config: OPERATION_CONFIG,
         document,
       }),
     ).toHaveProperty('request.body', {
@@ -1222,8 +1246,9 @@ describe('transformOas3Operation', () => {
 
     expect(
       transformOas3Operation.bind(null, {
-        path: '/pets',
+        name: '/pets',
         method: 'post',
+        config: OPERATION_CONFIG,
         document,
       }),
     ).not.toThrow();
@@ -1252,7 +1277,9 @@ describe('transformOas3Operation', () => {
       },
     };
 
-    expect(transformOas3Operation({ document, path: '/hello/test', method: 'get' })).toStrictEqual({
+    expect(
+      transformOas3Operation({ document, name: '/hello/test', method: 'get', config: OPERATION_CONFIG }),
+    ).toStrictEqual({
       id: 'http_operation-undefined-get-/hello/test',
       iid: 'get-test',
       method: 'get',
@@ -1364,8 +1391,9 @@ describe('transformOas3Operation', () => {
 
       expect(
         transformOas3Operation({
-          path: '/users/{userId}',
+          name: '/users/{userId}',
           method: 'get',
+          config: OPERATION_CONFIG,
           document,
         }),
       ).toEqual(
@@ -1393,8 +1421,9 @@ describe('transformOas3Operation', () => {
 
       expect(
         transformOas3Operation({
-          path: '/pet',
+          name: '/pet',
           method: 'get',
+          config: OPERATION_CONFIG,
           document,
         }),
       ).toEqual(
@@ -1484,8 +1513,9 @@ describe('transformOas3Operation', () => {
 
       expect(
         transformOas3Operation({
-          path: '/users/{userId}',
+          name: '/users/{userId}',
           method: 'get',
+          config: OPERATION_CONFIG,
           document,
         }),
       ).toHaveProperty('responses', [
@@ -1528,8 +1558,9 @@ describe('transformOas3Operation', () => {
 
       expect(
         transformOas3Operation({
-          path: '/subscribe',
+          name: '/subscribe',
           method: 'connect',
+          config: OPERATION_CONFIG,
           document,
         }),
       ).toHaveProperty('request.body', {

--- a/src/oas3/__tests__/operation.test.ts
+++ b/src/oas3/__tests__/operation.test.ts
@@ -1,10 +1,9 @@
-import { OpenAPIObject } from 'openapi3-ts';
-
 import { setSkipHashing } from '../../hash';
 import {
   transformOas3Operation as _transformOas3Operation,
   transformOas3Operations as _transformOas3Operations,
 } from '../operation';
+import { OpenAPIObject } from '../types';
 
 setSkipHashing(true);
 

--- a/src/oas3/__tests__/service.test.ts
+++ b/src/oas3/__tests__/service.test.ts
@@ -1,7 +1,6 @@
-import { OpenAPIObject } from 'openapi3-ts';
-
 import { setSkipHashing } from '../../hash';
 import { transformOas3Service as _transformOas3Service } from '../service';
+import { OpenAPIObject } from '../types';
 
 setSkipHashing(true);
 

--- a/src/oas3/operation.ts
+++ b/src/oas3/operation.ts
@@ -1,11 +1,16 @@
-import { DeepPartial, IHttpOperation } from '@stoplight/types';
+import { DeepPartial, IHttpEndpointOperation, IHttpOperation, IHttpWebhookOperation } from '@stoplight/types';
 import pickBy = require('lodash.pickby');
 import type { OpenAPIObject } from 'openapi3-ts';
 
 import { isNonNullable } from '../guards';
-import { OPERATION_CONFIG, transformOasEndpointOperation, transformOasEndpointOperations } from '../oas';
+import {
+  OPERATION_CONFIG,
+  transformOasEndpointOperation,
+  transformOasEndpointOperations,
+  WEBHOOK_CONFIG,
+} from '../oas';
 import { createContext } from '../oas/context';
-import type { Oas3HttpOperationTransformer } from '../oas/types';
+import type { Oas3HttpEndpointOperationTransformer } from '../oas/types';
 import { Fragment, TransformerContext } from '../types';
 import { translateToCallbacks } from './transformers/callbacks';
 import { translateToRequest } from './transformers/request';
@@ -17,10 +22,29 @@ export function transformOas3Operations<T extends Fragment = DeepPartial<OpenAPI
   document: T,
   ctx?: TransformerContext<T>,
 ): IHttpOperation[] {
-  return transformOasEndpointOperations(document, transformOas3Operation, OPERATION_CONFIG, void 0, ctx);
+  return transformOasEndpointOperations(
+    document,
+    transformOas3Operation,
+    OPERATION_CONFIG,
+    void 0,
+    ctx,
+  ) as unknown as IHttpOperation[];
 }
 
-export const transformOas3Operation: Oas3HttpOperationTransformer = ({
+export function transformOas3WebhookOperations<T extends Fragment = DeepPartial<OpenAPIObject>>(
+  document: T,
+  ctx?: TransformerContext<T>,
+): IHttpWebhookOperation[] {
+  return transformOasEndpointOperations(
+    document,
+    transformOas3Operation,
+    WEBHOOK_CONFIG,
+    void 0,
+    ctx,
+  ) as unknown as IHttpWebhookOperation[];
+}
+
+export const transformOas3Operation: Oas3HttpEndpointOperationTransformer = ({
   document: _document,
   name,
   method,
@@ -45,5 +69,5 @@ export const transformOas3Operation: Oas3HttpOperationTransformer = ({
       },
       isNonNullable,
     ),
-  } as unknown as IHttpOperation;
+  } as unknown as IHttpEndpointOperation;
 };

--- a/src/oas3/service.ts
+++ b/src/oas3/service.ts
@@ -46,6 +46,7 @@ export const bundleOas3Service: Oas3HttpServiceBundle = ({ document: _document }
   return {
     ...service,
     operations,
+    webhooks: [],
     components,
   };
 };

--- a/src/oas3/service.ts
+++ b/src/oas3/service.ts
@@ -1,5 +1,5 @@
 import { isPlainObject } from '@stoplight/json';
-import type { HttpSecurityScheme, IHttpOperation, Optional } from '@stoplight/types';
+import type { HttpSecurityScheme, IHttpOperation, IHttpWebhookOperation, Optional } from '@stoplight/types';
 import pickBy = require('lodash.pickby');
 
 import { withContext } from '../context';
@@ -14,7 +14,7 @@ import { OasVersion } from '../oas/types';
 import type { ArrayCallbackParameters } from '../types';
 import { entries } from '../utils';
 import { isSecurityScheme } from './guards';
-import { transformOas3Operations } from './operation';
+import { transformOas3Operations, transformOas3WebhookOperations } from './operation';
 import { translateToCallbacks } from './transformers/callbacks';
 import { translateToExample } from './transformers/examples';
 import { translateToSharedParameters } from './transformers/parameters';
@@ -42,11 +42,12 @@ export const bundleOas3Service: Oas3HttpServiceBundle = ({ document: _document }
   };
 
   const operations = transformOas3Operations(document, ctx) as unknown as IHttpOperation<true>[];
+  const webhooks = transformOas3WebhookOperations(document, ctx) as unknown as IHttpWebhookOperation<true>[];
 
   return {
     ...service,
     operations,
-    webhooks: [],
+    webhooks,
     components,
   };
 };

--- a/src/oas3/transformers/__tests__/callbacks.test.ts
+++ b/src/oas3/transformers/__tests__/callbacks.test.ts
@@ -1,7 +1,7 @@
 import { DeepPartial } from '@stoplight/types';
-import { OpenAPIObject } from 'openapi3-ts';
 
 import { createContext } from '../../../oas/context';
+import { OpenAPIObject } from '../../types';
 import { translateToCallbacks as _translateToCallbacks } from '../callbacks';
 
 const translateToCallbacks = (document: DeepPartial<OpenAPIObject>, callbacks: unknown) =>

--- a/src/oas3/transformers/__tests__/responses.test.ts
+++ b/src/oas3/transformers/__tests__/responses.test.ts
@@ -1,7 +1,7 @@
 import type { DeepPartial } from '@stoplight/types';
-import { OpenAPIObject } from 'openapi3-ts';
 
 import { createContext } from '../../../oas/context';
+import { OpenAPIObject } from '../../types';
 import { translateToResponses as _translateToResponses } from '../responses';
 
 const translateToResponses = (document: DeepPartial<OpenAPIObject>, responses: unknown) =>

--- a/src/oas3/transformers/__tests__/securities.test.ts
+++ b/src/oas3/transformers/__tests__/securities.test.ts
@@ -1,8 +1,8 @@
 import { DeepPartial } from '@stoplight/types';
-import { OpenAPIObject } from 'openapi3-ts';
 
 import { createContext } from '../../../oas/context';
 import { OperationSecurities } from '../../accessors';
+import { OpenAPIObject } from '../../types';
 import { translateToSecurities as _translateToSecurities } from '../securities';
 
 const translateToSecurities = (document: DeepPartial<OpenAPIObject>, operationSecurities: OperationSecurities) =>

--- a/src/oas3/transformers/__tests__/servers.test.ts
+++ b/src/oas3/transformers/__tests__/servers.test.ts
@@ -1,7 +1,7 @@
 import { DeepPartial } from '@stoplight/types';
-import { OpenAPIObject } from 'openapi3-ts';
 
 import { createContext } from '../../../oas/context';
+import { OpenAPIObject } from '../../types';
 import { translateToServers as _translateToServers } from '../servers';
 
 const translateToServers = (

--- a/src/oas3/transformers/callbacks.ts
+++ b/src/oas3/transformers/callbacks.ts
@@ -3,6 +3,7 @@ import type { OpenAPIObject } from 'openapi3-ts';
 
 import { createContext } from '../../oas/context';
 import { isReferenceObject } from '../../oas/guards';
+import { OPERATION_CONFIG } from '../../oas/operation';
 import { entries } from '../../utils';
 import { transformOas3Operation } from '../operation';
 import type { Oas3TranslateFunction } from '../types';
@@ -35,7 +36,8 @@ export const translateToCallbacks: Oas3TranslateFunction<
             ...transformOas3Operation({
               document,
               method,
-              path,
+              name: path,
+              config: OPERATION_CONFIG,
               ctx,
             }),
             key: callbackName,

--- a/src/oas3/transformers/callbacks.ts
+++ b/src/oas3/transformers/callbacks.ts
@@ -41,7 +41,7 @@ export const translateToCallbacks: Oas3TranslateFunction<
               ctx,
             }),
             key: callbackName,
-          });
+          } as IHttpCallbackOperation);
         }
       }
 

--- a/src/oas3/types.ts
+++ b/src/oas3/types.ts
@@ -1,5 +1,7 @@
 import { DeepPartial } from '@stoplight/types';
-import { OpenAPIObject } from 'openapi3-ts';
+import { OpenAPIObject as _OpenAPIObject } from 'openapi3-ts';
+import { PathItemObject } from 'openapi3-ts/src/model/OpenApi';
+import { ISpecificationExtension } from 'openapi3-ts/src/model/SpecificationExtension';
 
 import { TranslateFunction } from '../types';
 
@@ -8,3 +10,11 @@ export type Oas3TranslateFunction<P extends unknown[], R extends unknown = unkno
   P,
   R
 >;
+
+export interface OpenAPIObject extends _OpenAPIObject {
+  webhooks?: WebhooksObject;
+}
+
+export interface WebhooksObject extends ISpecificationExtension {
+  [name: string]: PathItemObject;
+}

--- a/src/postman/types.ts
+++ b/src/postman/types.ts
@@ -1,9 +1,13 @@
+import { IHttpOperation } from '@stoplight/types';
 import type { CollectionDefinition } from 'postman-collection';
 
-import type { HttpOperationTransformer } from '../types';
+import type { HttpEndpointOperationTransformer } from '../types';
 
-export type PostmanCollectionHttpOperationTransformer = HttpOperationTransformer<{
-  document: CollectionDefinition;
-  path: string;
-  method: string;
-}>;
+export type PostmanCollectionHttpOperationTransformer = HttpEndpointOperationTransformer<
+  {
+    document: CollectionDefinition;
+    path: string;
+    method: string;
+  },
+  IHttpOperation
+>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { IBundledHttpService, IHttpOperation, IHttpService } from '@stoplight/types';
+import type { IBundledHttpService, IHttpEndpointOperation, IHttpService } from '@stoplight/types';
 
 import type { idGenerators } from './generators';
 
@@ -20,20 +20,33 @@ export type HttpServiceTransformer<T> = (opts: T) => IHttpService;
 
 export type HttpServiceBundle<T> = (opts: T) => IBundledHttpService;
 
-export interface ITransformOperationOpts<T extends Fragment> {
+export type EndpointOperationConfig =
+  | {
+      type: 'operation';
+      documentProp: 'paths';
+      nameProp: 'path';
+    }
+  | {
+      type: 'webhook';
+      documentProp: 'webhooks';
+      nameProp: 'name';
+    };
+
+export interface ITransformEndpointOperationOpts<T extends Fragment> {
   document: T;
-  path: string;
+  name: string;
   method: string;
+  config: EndpointOperationConfig;
   ctx?: TransformerContext<T>;
 }
 
-export type HttpOperationTransformer<T> = (opts: T) => IHttpOperation;
+export type HttpEndpointOperationTransformer<T, TEndpoint extends IHttpEndpointOperation> = (opts: T) => TEndpoint;
 
 export type HttpSecurityKind = 'requirement' | 'scheme';
 
 export type ArrayCallbackParameters<T> = [T, number, T[]];
 
-export type AvailableContext = 'service' | 'path' | 'operation' | 'callback';
+export type AvailableContext = 'service' | 'path' | 'operation' | 'callback' | 'webhook' | 'webhookName';
 
 export type References = Record<string, { resolved: boolean; value: string }>;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1483,10 +1483,10 @@
   resolved "https://registry.yarnpkg.com/@stoplight/test-utils/-/test-utils-0.0.1.tgz#b0d38c8a0abebda2dacbc2aa6a4f9bec44878e7b"
   integrity sha512-Cj3waLFR9bYLG8yvgkjXMxOfiVdewRyrKdH5RQpttVNfKj5UF+mElofPcHn/UfiOuxK3t5rbsdMfS26LK5tdQg==
 
-"@stoplight/types@14.0.0":
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/@stoplight/types/-/types-14.0.0.tgz#f444490664c2c16d5f06265fcbac8d94a33481e8"
-  integrity sha512-w7Ejau6TaB7RqR0vWzGJSdmgLEYD2frjgbHPZoxgGQwAq/R8Qh/D9p9Bl9JFdii+YTL5xoDjyX0c1WDRlbMV8g==
+"@stoplight/types@14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@stoplight/types/-/types-14.1.0.tgz#36b04488acc1d8ab5bb712416f50d3bc99610b34"
+  integrity sha512-fL8Nzw03+diALw91xHEHA5Q0WCGeW9WpPgZQjodNUWogAgJ56aJs03P9YzsQ1J6fT7/XjDqHMgn7/RlsBzB/SQ==
   dependencies:
     "@types/json-schema" "^7.0.4"
     utility-types "^3.10.0"


### PR DESCRIPTION
this is a set of changes to support oas 3.1 webhooks. this does have breaking changes to make the operation parsing compatible both with regular operations and webhooks.