### PR TITLE
fix: callback operation ids

### DIFF
--- a/src/__tests__/generators.test.ts
+++ b/src/__tests__/generators.test.ts
@@ -20,12 +20,31 @@ describe('idGenerators', () => {
     expect(id1).toEqual(id2);
   });
   it('httpCallbackOperation ids should be unique', () => {
-    const operation1 = { parentId: '12345', method: 'post', path: '{$request.body#/returnedPetAdoptedUrl}' };
-    const operation2 = { parentId: '12345', method: 'post', path: '{$request.body#/newPetAvailableUrl}' };
+    const operation1 = {
+      parentId: '12345',
+      method: 'post',
+      path: '{$request.body#/returnedPetAdoptedUrl}',
+      key: 'returnedPetAdopted',
+    };
+    const operation2 = {
+      parentId: '12345',
+      method: 'post',
+      path: '{$request.body#/newPetAvailableUrl}',
+      key: 'newPetAvailable',
+    };
+    const operation3 = {
+      parentId: '12345',
+      method: 'post',
+      path: '{$request.body#/newPetAvailableUrl}',
+      key: 'newPet',
+    };
     const id1 = idGenerators.httpCallbackOperation(operation1);
     const id2 = idGenerators.httpCallbackOperation(operation2);
-    expect(id1).toEqual('http_callback-12345-post-{$request.body#/returnedPetAdoptedUrl}');
-    expect(id2).toEqual('http_callback-12345-post-{$request.body#/newPetAvailableUrl}');
+    const id3 = idGenerators.httpCallbackOperation(operation3);
+    expect(id1).toEqual('http_callback-12345-post-{$request.body#/returnedPetAdoptedUrl}-returnedPetAdopted');
+    expect(id2).toEqual('http_callback-12345-post-{$request.body#/newPetAvailableUrl}-newPetAvailable');
+    expect(id3).toEqual('http_callback-12345-post-{$request.body#/newPetAvailableUrl}-newPet');
     expect(id1).not.toEqual(id2);
+    expect(id2).not.toEqual(id3);
   });
 });

--- a/src/__tests__/generators.test.ts
+++ b/src/__tests__/generators.test.ts
@@ -41,9 +41,9 @@ describe('idGenerators', () => {
     const id1 = idGenerators.httpCallbackOperation(operation1);
     const id2 = idGenerators.httpCallbackOperation(operation2);
     const id3 = idGenerators.httpCallbackOperation(operation3);
-    expect(id1).toEqual('http_callback-12345-post-{$request.body#/returnedPetAdoptedUrl}-returnedPetAdopted');
-    expect(id2).toEqual('http_callback-12345-post-{$request.body#/newPetAvailableUrl}-newPetAvailable');
-    expect(id3).toEqual('http_callback-12345-post-{$request.body#/newPetAvailableUrl}-newPet');
+    expect(id1).toEqual('http_callback-12345-returnedPetAdopted-post-{$request.body#/returnedPetAdoptedUrl}');
+    expect(id2).toEqual('http_callback-12345-newPetAvailable-post-{$request.body#/newPetAvailableUrl}');
+    expect(id3).toEqual('http_callback-12345-newPet-post-{$request.body#/newPetAvailableUrl}');
     expect(id1).not.toEqual(id2);
     expect(id2).not.toEqual(id3);
   });

--- a/src/generators.ts
+++ b/src/generators.ts
@@ -48,8 +48,8 @@ export const idGenerators = {
     return join(['http_webhook_operation', props.parentId, props.method, sanitizePath(props.name)]);
   },
 
-  httpCallbackOperation: (props: Context & { method: string; path: string }) => {
-    return join(['http_callback', props.parentId, props.method, props.path]);
+  httpCallbackOperation: (props: Context & { method: string; path: string; key: string }) => {
+    return join(['http_callback', props.parentId, props.method, props.path, props.key]);
   },
 
   httpPathParam: (props: Context & { keyOrName: string }) => {

--- a/src/generators.ts
+++ b/src/generators.ts
@@ -49,7 +49,7 @@ export const idGenerators = {
   },
 
   httpCallbackOperation: (props: Context & { method: string; path: string; key: string }) => {
-    return join(['http_callback', props.parentId, props.method, props.path, props.key]);
+    return join(['http_callback', props.parentId, props.key, props.method, props.path]);
   },
 
   httpPathParam: (props: Context & { keyOrName: string }) => {

--- a/src/oas/__tests__/__snapshots__/operation.test.ts.snap
+++ b/src/oas/__tests__/__snapshots__/operation.test.ts.snap
@@ -1031,6 +1031,64 @@ Array [
     "tags": Array [],
   },
   Object {
+    "callbacks": Array [
+      Object {
+        "extensions": Object {},
+        "id": "http_callback-undefined-post-{$request.body#/callbackUrl}-MyEvent",
+        "key": "MyEvent",
+        "method": "post",
+        "path": "{$request.body#/callbackUrl}",
+        "request": Object {
+          "body": Object {
+            "contents": Array [
+              Object {
+                "encodings": Array [],
+                "examples": Array [],
+                "id": "http_media-http_request_body-http_callback-undefined-post-{$request.body#/callbackUrl}-MyEvent-application/json",
+                "mediaType": "application/json",
+                "schema": Object {
+                  "$schema": "http://json-schema.org/draft-07/schema#",
+                  "properties": Object {
+                    "message": Object {
+                      "examples": Array [
+                        "Some event happened",
+                      ],
+                      "type": "string",
+                    },
+                  },
+                  "required": Array [
+                    "message",
+                  ],
+                  "type": "object",
+                  "x-stoplight": Object {
+                    "id": "schema-http_media-http_request_body-http_callback-undefined-post-{$request.body#/callbackUrl}-MyEvent-application/json-",
+                  },
+                },
+              },
+            ],
+            "id": "http_request_body-http_callback-undefined-post-{$request.body#/callbackUrl}-MyEvent",
+            "required": true,
+          },
+          "cookie": Array [],
+          "headers": Array [],
+          "path": Array [],
+          "query": Array [],
+        },
+        "responses": Array [
+          Object {
+            "code": "200",
+            "contents": Array [],
+            "description": "Your server returns this code if it accepts the callback",
+            "headers": Array [],
+            "id": "http_response-http_callback-undefined-post-{$request.body#/callbackUrl}-MyEvent-200",
+          },
+        ],
+        "security": Array [],
+        "securityDeclarationType": "inheritedFromService",
+        "servers": Array [],
+        "tags": Array [],
+      },
+    ],
     "description": "",
     "extensions": Object {},
     "id": "http_operation-abc-put-/pet/{}",

--- a/src/oas/__tests__/__snapshots__/operation.test.ts.snap
+++ b/src/oas/__tests__/__snapshots__/operation.test.ts.snap
@@ -1034,7 +1034,7 @@ Array [
     "callbacks": Array [
       Object {
         "extensions": Object {},
-        "id": "http_callback-undefined-post-{$request.body#/callbackUrl}-MyEvent",
+        "id": "http_callback-undefined-MyEvent-post-{$request.body#/callbackUrl}",
         "key": "MyEvent",
         "method": "post",
         "path": "{$request.body#/callbackUrl}",
@@ -1044,7 +1044,7 @@ Array [
               Object {
                 "encodings": Array [],
                 "examples": Array [],
-                "id": "http_media-http_request_body-http_callback-undefined-post-{$request.body#/callbackUrl}-MyEvent-application/json",
+                "id": "http_media-http_request_body-http_callback-undefined-MyEvent-post-{$request.body#/callbackUrl}-application/json",
                 "mediaType": "application/json",
                 "schema": Object {
                   "$schema": "http://json-schema.org/draft-07/schema#",
@@ -1061,12 +1061,12 @@ Array [
                   ],
                   "type": "object",
                   "x-stoplight": Object {
-                    "id": "schema-http_media-http_request_body-http_callback-undefined-post-{$request.body#/callbackUrl}-MyEvent-application/json-",
+                    "id": "schema-http_media-http_request_body-http_callback-undefined-MyEvent-post-{$request.body#/callbackUrl}-application/json-",
                   },
                 },
               },
             ],
-            "id": "http_request_body-http_callback-undefined-post-{$request.body#/callbackUrl}-MyEvent",
+            "id": "http_request_body-http_callback-undefined-MyEvent-post-{$request.body#/callbackUrl}",
             "required": true,
           },
           "cookie": Array [],
@@ -1080,7 +1080,7 @@ Array [
             "contents": Array [],
             "description": "Your server returns this code if it accepts the callback",
             "headers": Array [],
-            "id": "http_response-http_callback-undefined-post-{$request.body#/callbackUrl}-MyEvent-200",
+            "id": "http_response-http_callback-undefined-MyEvent-post-{$request.body#/callbackUrl}-200",
           },
         ],
         "security": Array [],

--- a/src/oas/__tests__/fixtures/oas3-kitchen-sink.json
+++ b/src/oas/__tests__/fixtures/oas3-kitchen-sink.json
@@ -132,6 +132,38 @@
         ],
         "requestBody": {
           "$ref": "#/components/requestBodies/Pet"
+        },
+        "callbacks": {
+          "MyEvent": {
+            "{$request.body#/callbackUrl}": {
+              "post": {
+                "requestBody": {
+                  "required": true,
+                  "content": {
+                    "application/json": {
+                      "schema": {
+                        "type": "object",
+                        "properties": {
+                          "message": {
+                            "type": "string",
+                            "example": "Some event happened"
+                          }
+                        },
+                        "required": [
+                          "message"
+                        ]
+                      }
+                    }
+                  }
+                },
+                "responses": {
+                  "200": {
+                    "description": "Your server returns this code if it accepts the callback"
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/src/oas/operation.ts
+++ b/src/oas/operation.ts
@@ -62,9 +62,9 @@ export function transformOasEndpointOperations<
 
 export const transformOasEndpointOperation: TranslateFunction<
   DeepPartial<OpenAPIObject> | DeepPartial<Spec>,
-  [config: EndpointOperationConfig, name: string, method: string],
+  [config: EndpointOperationConfig, name: string, method: string, key?: string],
   Omit<IHttpEndpointOperation, 'responses' | 'request' | 'servers' | 'security' | 'callbacks'>
-> = function ({ type, documentProp, nameProp }: EndpointOperationConfig, name: string, method: string) {
+> = function ({ type, documentProp, nameProp }: EndpointOperationConfig, name: string, method: string, key?: string) {
   const pathObj = this.maybeResolveLocalRef(this.document?.[documentProp]?.[name]) as PathsObject;
   if (typeof pathObj !== 'object' || pathObj === null) {
     throw new Error(`Could not find ${[documentProp, name].join('/')} in the provided spec.`);
@@ -89,6 +89,7 @@ export const transformOasEndpointOperation: TranslateFunction<
         parentId: serviceId,
         method,
         path: name,
+        key: key ?? 'unknown',
       });
   } else if (type === 'operation') {
     id = this.ids.operation =

--- a/src/oas/operation.ts
+++ b/src/oas/operation.ts
@@ -89,7 +89,7 @@ export const transformOasEndpointOperation: TranslateFunction<
         parentId: serviceId,
         method,
         path: name,
-        key: key ?? 'unknown',
+        key: key ?? '',
       });
   } else if (type === 'operation') {
     id = this.ids.operation =

--- a/src/oas3/operation.ts
+++ b/src/oas3/operation.ts
@@ -49,9 +49,10 @@ export const transformOas3Operation: Oas3HttpEndpointOperationTransformer = ({
   name,
   method,
   config,
+  key,
   ctx = createContext(_document),
 }) => {
-  const httpOperation = transformOasEndpointOperation.call(ctx, config, name, method);
+  const httpOperation = transformOasEndpointOperation.call(ctx, config, name, method, key);
   const parentObj = ctx.maybeResolveLocalRef(ctx.document[config.documentProp]![name]) as Fragment;
   const operation = ctx.maybeResolveLocalRef(parentObj[method]) as Fragment;
 

--- a/src/oas3/transformers/__tests__/callbacks.test.ts
+++ b/src/oas3/transformers/__tests__/callbacks.test.ts
@@ -100,7 +100,7 @@ describe('translateToCallbacks', () => {
       {
         key: 'newPetWebhook',
         extensions: {},
-        id: '1e277a6571f2c',
+        id: '8598295bca7aa',
         method: 'post',
         path: '{$request.body#/newPetAvailableUrl}',
         request: {
@@ -152,7 +152,7 @@ describe('translateToCallbacks', () => {
       {
         key: 'newPetWebhook',
         extensions: {},
-        id: '3495b9c5e52ff',
+        id: '602f44a0af2a3',
         method: 'post',
         path: '{$request.body#/returnedPetAvailableUrl}',
         request: {
@@ -204,7 +204,7 @@ describe('translateToCallbacks', () => {
       {
         key: 'petAdopted',
         extensions: {},
-        id: '277b9b7c0fcbe',
+        id: '54f5719cae277',
         method: 'post',
         path: '{$request.body#/adoptedUrl}',
         request: {

--- a/src/oas3/transformers/__tests__/callbacks.test.ts
+++ b/src/oas3/transformers/__tests__/callbacks.test.ts
@@ -100,7 +100,7 @@ describe('translateToCallbacks', () => {
       {
         key: 'newPetWebhook',
         extensions: {},
-        id: '3245690b6a7fc',
+        id: '1e277a6571f2c',
         method: 'post',
         path: '{$request.body#/newPetAvailableUrl}',
         request: {
@@ -152,7 +152,7 @@ describe('translateToCallbacks', () => {
       {
         key: 'newPetWebhook',
         extensions: {},
-        id: '07041d5723f4a',
+        id: '3495b9c5e52ff',
         method: 'post',
         path: '{$request.body#/returnedPetAvailableUrl}',
         request: {
@@ -204,7 +204,7 @@ describe('translateToCallbacks', () => {
       {
         key: 'petAdopted',
         extensions: {},
-        id: '2333951a518f9',
+        id: '277b9b7c0fcbe',
         method: 'post',
         path: '{$request.body#/adoptedUrl}',
         request: {

--- a/src/oas3/transformers/callbacks.ts
+++ b/src/oas3/transformers/callbacks.ts
@@ -31,12 +31,18 @@ export const translateToCallbacks: Oas3TranslateFunction<
           const ctx = createContext(document);
           ctx.context = 'callback';
           Object.assign(ctx.ids, this.ids);
-          ctx.ids.operation = this.generateId.httpCallbackOperation({ parentId: this.ids.service, method, path });
+          ctx.ids.operation = this.generateId.httpCallbackOperation({
+            parentId: this.ids.service,
+            method,
+            path,
+            key: callbackName,
+          });
           results.push({
             ...transformOas3Operation({
               document,
               method,
               name: path,
+              key: callbackName,
               config: OPERATION_CONFIG,
               ctx,
             }),

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export interface ITransformEndpointOperationOpts<T extends Fragment> {
   document: T;
   name: string;
   method: string;
+  key?: string;
   config: EndpointOperationConfig;
   ctx?: TransformerContext<T>;
 }


### PR DESCRIPTION
Addresses: https://github.com/stoplightio/platform-internal/issues/18498

## Motivation and Context
Callback ids are currently being generated based on operation method and path. This may lead to duplicated ids in case where one operation has more than one callbacks defined.

## Description
Adds additional key property (callback name) when generating ids for callback nodes.


## How Has This Been Tested?
Tests updated

## Screenshot(s)/recordings(s)
<!-- If applicable, add screenshots or gifs to help demonstrate the changes. -->
<!-- If not applicable, remove this screenshots section before creating the PR. -->


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [ ] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [ ] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
