### PR TITLE
fix(oas): extensions on tags is incorrectly spread

### DIFF
--- a/src/oas/__tests__/__snapshots__/service.test.ts.snap
+++ b/src/oas/__tests__/__snapshots__/service.test.ts.snap
@@ -71,6 +71,7 @@ Object {
   "tags": Array [
     Object {
       "description": "Everything about your Pets",
+      "extensions": Object {},
       "externalDocs": Object {
         "description": "Find out more",
         "url": "http://swagger.io",
@@ -80,11 +81,13 @@ Object {
     },
     Object {
       "description": "Access to Petstore orders",
+      "extensions": Object {},
       "id": "tag-store",
       "name": "store",
     },
     Object {
       "description": "Operations about user",
+      "extensions": Object {},
       "externalDocs": Object {
         "description": "Find out more about our store",
         "url": "http://swagger.io",
@@ -93,11 +96,13 @@ Object {
       "name": "user",
     },
     Object {
+      "extensions": Object {
+        "x-service-tag-extension": Object {
+          "hello": "world",
+        },
+      },
       "id": "tag-x-extension-in-tag",
       "name": "x-extension-in-tag",
-      "x-service-tag-extension": Object {
-        "hello": "world",
-      },
     },
   ],
   "termsOfService": "http://swagger.io/terms/",
@@ -176,6 +181,7 @@ Object {
   "tags": Array [
     Object {
       "description": "Everything about your Pets",
+      "extensions": Object {},
       "externalDocs": Object {
         "description": "Find out more",
         "url": "http://swagger.io",
@@ -185,11 +191,13 @@ Object {
     },
     Object {
       "description": "Access to Petstore orders",
+      "extensions": Object {},
       "id": "tag-store",
       "name": "store",
     },
     Object {
       "description": "Operations about user",
+      "extensions": Object {},
       "externalDocs": Object {
         "description": "Find out more about our store",
         "url": "http://swagger.io",
@@ -198,11 +206,13 @@ Object {
       "name": "user",
     },
     Object {
+      "extensions": Object {
+        "x-service-tag-extension": Object {
+          "hello": "world",
+        },
+      },
       "id": "tag-x-extension-in-tag",
       "name": "x-extension-in-tag",
-      "x-service-tag-extension": Object {
-        "hello": "world",
-      },
     },
   ],
   "termsOfService": "http://swagger.io/terms/",

--- a/src/oas/tags.ts
+++ b/src/oas/tags.ts
@@ -49,7 +49,7 @@ export const translateTagDefinition: TranslateFunction<
     ),
 
     ...toExternalDocs(tag.externalDocs),
-    ...extensions,
+    extensions,
   };
 };
 

--- a/src/oas2/__tests__/__fixtures__/id/bundled.ts
+++ b/src/oas2/__tests__/__fixtures__/id/bundled.ts
@@ -14,6 +14,7 @@ export default {
       // hash('tag-mutates')
       id: 'tag-mutates',
       name: 'mutates',
+      extensions: {},
     },
   ],
   extensions: {

--- a/src/oas2/__tests__/bundle.test.ts
+++ b/src/oas2/__tests__/bundle.test.ts
@@ -313,8 +313,10 @@ describe('bundleOas2Service', () => {
         {
           id: 'tag-service-tag-extension',
           name: 'service-tag-extension',
-          'x-service-tag-extension': {
-            hello: 'world',
+          extensions: {
+            'x-service-tag-extension': {
+              hello: 'world',
+            },
           },
         },
       ],

--- a/src/oas3/__tests__/__fixtures__/id/bundled.ts
+++ b/src/oas3/__tests__/__fixtures__/id/bundled.ts
@@ -14,6 +14,7 @@ export default {
       // hash('tag-mutates')
       id: 'tag-mutates',
       name: 'mutates',
+      extensions: {},
     },
   ],
   components: {

--- a/src/oas3/__tests__/__fixtures__/id/legacy.ts
+++ b/src/oas3/__tests__/__fixtures__/id/legacy.ts
@@ -41,6 +41,7 @@ export default [
         // hash(`tag-${tag.name}`)
         id: 'tag-mutates',
         name: 'mutates',
+        extensions: {},
       },
     ],
     extensions: {

--- a/src/oas3/__tests__/bundle.test.ts
+++ b/src/oas3/__tests__/bundle.test.ts
@@ -930,8 +930,10 @@ describe('bundleOas3Service', () => {
         {
           id: 'tag-service-tag-extension',
           name: 'service-tag-extension',
-          'x-service-tag-extension': {
-            hello: 'world',
+          extensions: {
+            'x-service-tag-extension': {
+              hello: 'world',
+            },
           },
         },
       ],


### PR DESCRIPTION
`INodeTag` extends `ISpecExtensions` and as such should have `extensions` property containing all collected spec extensions.
We accidentally spread `extensions` causing all spec extensions to be placed among other INodeTag members.