### PR TITLE
feat(oas3): return security scopes for types other than oauth2

### DIFF
--- a/src/oas3/__tests__/accessors.test.ts
+++ b/src/oas3/__tests__/accessors.test.ts
@@ -1,4 +1,5 @@
 import { DeepPartial } from '@stoplight/types';
+import { SecuritySchemeType } from 'openapi3-ts';
 
 import { setSkipHashing } from '../../hash';
 import { getSecurities as _getSecurities, OperationSecurities } from '../accessors';
@@ -110,6 +111,35 @@ describe('getOas3Securities', () => {
       ],
     ]);
   });
+
+  it.each<SecuritySchemeType>(['http', 'apiKey', 'openIdConnect'])(
+    'given global securities and matching operation scheme with scopes should return scopes as extensions for security scheme type: %s',
+    type => {
+      expect(
+        getSecurities({
+          security: [{ operationScheme: ['image:read'] }],
+          components: {
+            securitySchemes: {
+              operationScheme: {
+                type,
+              },
+            },
+          },
+        }),
+      ).toStrictEqual([
+        [
+          [
+            'operationScheme',
+            {
+              type,
+              ['x-scopes']: ['image:read'],
+              extensions: { ['x-scopes']: ['image:read'] },
+            },
+          ],
+        ],
+      ]);
+    },
+  );
 
   it('given global securities and matching spec and invalid operation scheme should return empty array', () => {
     expect(

--- a/src/oas3/accessors.ts
+++ b/src/oas3/accessors.ts
@@ -45,11 +45,14 @@ export function getSecurities(
           ];
         }
 
+        const extensions = scopes?.length ? { ['x-scopes']: scopes } : {};
+
         return [
           opScheme,
           {
             ...definition,
-            extensions: getExtensions(definition),
+            ...extensions,
+            extensions: getExtensions({ ...definition, ...extensions }),
           },
         ];
       })


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context
The PR is required for displaying security scheme roles in elements: https://github.com/stoplightio/elements/issues/2491

## Description
The `scopes` value has been added to `extensions` as it's not part of the security scheme, so I didn't want to extend `HttpSecurityScheme`.

## How Has This Been Tested?
Tested locally in elements.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [ ] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [x] All new and existing tests pass locally (excluding flaky CI tests).
