### PR TITLE
fix(oas): prevent duplicate null values in enum array [ISSUE-271]

### DIFF
--- a/src/oas/__tests__/__snapshots__/operation.test.ts.snap
+++ b/src/oas/__tests__/__snapshots__/operation.test.ts.snap
@@ -792,7 +792,6 @@ Array [
                     null,
                     "foo",
                     "bar",
-                    null,
                   ],
                   "type": Array [
                     "string",
@@ -877,7 +876,6 @@ Array [
                     null,
                     "foo",
                     "bar",
-                    null,
                   ],
                   "type": Array [
                     "string",
@@ -1194,7 +1192,6 @@ Array [
                     null,
                     "foo",
                     "bar",
-                    null,
                   ],
                   "type": Array [
                     "string",
@@ -1279,7 +1276,6 @@ Array [
                     null,
                     "foo",
                     "bar",
-                    null,
                   ],
                   "type": Array [
                     "string",

--- a/src/oas/__tests__/__snapshots__/operation.test.ts.snap
+++ b/src/oas/__tests__/__snapshots__/operation.test.ts.snap
@@ -787,6 +787,29 @@ Array [
                   ],
                   "type": "string",
                 },
+                "nullableEnumExplicit": Object {
+                  "enum": Array [
+                    null,
+                    "foo",
+                    "bar",
+                    null,
+                  ],
+                  "type": Array [
+                    "string",
+                    "null",
+                  ],
+                },
+                "nullableEnumImplicit": Object {
+                  "enum": Array [
+                    "foo",
+                    "bar",
+                    null,
+                  ],
+                  "type": Array [
+                    "string",
+                    "null",
+                  ],
+                },
                 "photoUrls": Object {
                   "items": Object {
                     "type": "string",
@@ -848,6 +871,29 @@ Array [
                     "doggie",
                   ],
                   "type": "string",
+                },
+                "nullableEnumExplicit": Object {
+                  "enum": Array [
+                    null,
+                    "foo",
+                    "bar",
+                    null,
+                  ],
+                  "type": Array [
+                    "string",
+                    "null",
+                  ],
+                },
+                "nullableEnumImplicit": Object {
+                  "enum": Array [
+                    "foo",
+                    "bar",
+                    null,
+                  ],
+                  "type": Array [
+                    "string",
+                    "null",
+                  ],
                 },
                 "photoUrls": Object {
                   "items": Object {
@@ -1143,6 +1189,29 @@ Array [
                   ],
                   "type": "string",
                 },
+                "nullableEnumExplicit": Object {
+                  "enum": Array [
+                    null,
+                    "foo",
+                    "bar",
+                    null,
+                  ],
+                  "type": Array [
+                    "string",
+                    "null",
+                  ],
+                },
+                "nullableEnumImplicit": Object {
+                  "enum": Array [
+                    "foo",
+                    "bar",
+                    null,
+                  ],
+                  "type": Array [
+                    "string",
+                    "null",
+                  ],
+                },
                 "photoUrls": Object {
                   "items": Object {
                     "type": "string",
@@ -1204,6 +1273,29 @@ Array [
                     "doggie",
                   ],
                   "type": "string",
+                },
+                "nullableEnumExplicit": Object {
+                  "enum": Array [
+                    null,
+                    "foo",
+                    "bar",
+                    null,
+                  ],
+                  "type": Array [
+                    "string",
+                    "null",
+                  ],
+                },
+                "nullableEnumImplicit": Object {
+                  "enum": Array [
+                    "foo",
+                    "bar",
+                    null,
+                  ],
+                  "type": Array [
+                    "string",
+                    "null",
+                  ],
                 },
                 "photoUrls": Object {
                   "items": Object {

--- a/src/oas/__tests__/fixtures/oas3-kitchen-sink.json
+++ b/src/oas/__tests__/fixtures/oas3-kitchen-sink.json
@@ -312,6 +312,16 @@
             "type": "string",
             "description": "pet status in the store",
             "enum": ["available", "pending", "sold"]
+          },
+          "nullableEnumImplicit": {
+            "type": "string",
+            "nullable": true,
+            "enum": ["foo", "bar"]
+          },
+          "nullableEnumExplicit": {
+            "type": "string",
+            "nullable": true,
+            "enum": [null, "foo", "bar"]
           }
         },
         "required": ["name", "photoUrls"]

--- a/src/oas/transformers/schema/keywords/nullable.ts
+++ b/src/oas/transformers/schema/keywords/nullable.ts
@@ -26,7 +26,7 @@ const createNullableConverter = (keyword: 'x-nullable' | 'nullable'): Converter 
     if (schema[keyword] === true) {
       schema.type = [schema.type, 'null'];
 
-      if (Array.isArray(schema.enum)) {
+      if (Array.isArray(schema.enum) && !schema.enum.includes(null)) {
         schema.enum = [...schema.enum, null];
       }
     } else {


### PR DESCRIPTION
## Motivation and Context

`null` is always appended to `enum` array for nullable enum property. This can result in an invalid JSON schema document when `null` is already included as part of the `enum` array. 
#271

## Description

Checks for a `null` value in the `enum` array before appending one.


## How Has This Been Tested?

Updated the OAS test fixture in f77dcf83d4964d6ba1c1c5291448fe839a35d436 to demonstrate issue in resultant snapshots.

Fix can be observed in 7452a4b394ebe0403dadeed8edee3b60a5763df7 where invalid `null` values are no longer present.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [x] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [x] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [x] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
